### PR TITLE
feat: quality-aware stream filtering (4K/UHD/HDR)

### DIFF
--- a/Lineuparr/FR_CanalPlus_TNT_lineup.json
+++ b/Lineuparr/FR_CanalPlus_TNT_lineup.json
@@ -1,0 +1,1141 @@
+{
+  "package": "Canal+ France (Numérotation TNT)",
+  "date": "2026-06-01",
+  "description": "Chaînes Canal+ France avec numérotation TNT, en vigueur à compter du 30 mars 2026",
+  "source": "Canal+ Plan de Service TNT 2026",
+  "notes": "Numérotation TNT utilisée sur les décodeurs Canal+ en France métropolitaine. Les chaînes gratuites de la TNT sont aux positions 1-25, les chaînes Canal+ abonnés à partir de 30. Les flux en direct (Canal+ Live, Eurosport 360), les services à la demande (VOD, Netflix, etc.) et les mosaïques ne sont pas inclus.",
+  "categories": {
+    "TNT Gratuite": [
+      {
+        "name": "TF1",
+        "number": 1
+      },
+      {
+        "name": "France 2",
+        "number": 2
+      },
+      {
+        "name": "France 3",
+        "number": 3
+      },
+      {
+        "name": "France 4",
+        "number": 4
+      },
+      {
+        "name": "France 5",
+        "number": 5
+      },
+      {
+        "name": "M6",
+        "number": 6
+      },
+      {
+        "name": "Arte",
+        "number": 7
+      },
+      {
+        "name": "LCP",
+        "number": 8
+      },
+      {
+        "name": "W9",
+        "number": 9
+      },
+      {
+        "name": "TMC",
+        "number": 10
+      },
+      {
+        "name": "TFX",
+        "number": 11
+      },
+      {
+        "name": "Gulli",
+        "number": 12
+      },
+      {
+        "name": "BFM TV",
+        "number": 13
+      },
+      {
+        "name": "CNews",
+        "number": 14
+      },
+      {
+        "name": "LCI",
+        "number": 15
+      },
+      {
+        "name": "France Info",
+        "number": 16
+      },
+      {
+        "name": "CSTAR",
+        "number": 17
+      },
+      {
+        "name": "T18",
+        "number": 18
+      },
+      {
+        "name": "Novo19",
+        "number": 19
+      },
+      {
+        "name": "TF1 Séries Films",
+        "number": 20
+      },
+      {
+        "name": "L'Équipe",
+        "number": 21
+      },
+      {
+        "name": "6ter",
+        "number": 22
+      },
+      {
+        "name": "RMC Story",
+        "number": 23
+      },
+      {
+        "name": "RMC Découverte",
+        "number": 24
+      },
+      {
+        "name": "RMC Life",
+        "number": 25
+      }
+    ],
+    "Canal+": [
+      {
+        "name": "Chaîne Événement",
+        "number": 29
+      },
+      {
+        "name": "Canal+",
+        "number": 30
+      },
+      {
+        "name": "Canal+Sport 360",
+        "number": 31
+      },
+      {
+        "name": "Canal+Foot",
+        "number": 32
+      },
+      {
+        "name": "Canal+Sport",
+        "number": 33
+      },
+      {
+        "name": "Canal+Box Office",
+        "number": 34
+      },
+      {
+        "name": "Canal+Grand Écran",
+        "number": 35
+      },
+      {
+        "name": "Canal+Cinéma(s)",
+        "number": 36
+      },
+      {
+        "name": "Canal+Docs",
+        "number": 38
+      },
+      {
+        "name": "Canal+Kids",
+        "number": 39
+      }
+    ],
+    "UHD": [
+      {
+        "name": "Canal+ UHD",
+        "number": 80
+      },
+      {
+        "name": "Événement Sport UHD",
+        "number": 81
+      },
+      {
+        "name": "France 2 UHD",
+        "number": 82
+      }
+    ],
+    "Cinéma": [
+      {
+        "name": "OCS",
+        "number": 53
+      },
+      {
+        "name": "Ciné+ Frisson",
+        "number": 54
+      },
+      {
+        "name": "Ciné+ Émotion",
+        "number": 55
+      },
+      {
+        "name": "Ciné+ Family",
+        "number": 56
+      },
+      {
+        "name": "Ciné+ Festival",
+        "number": 57
+      },
+      {
+        "name": "Ciné+ Classic",
+        "number": 58
+      },
+      {
+        "name": "Action",
+        "number": 65
+      },
+      {
+        "name": "TCM Cinéma",
+        "number": 66
+      }
+    ],
+    "Séries": [
+      {
+        "name": "Polar+",
+        "number": 71
+      },
+      {
+        "name": "Serieclub",
+        "number": 72
+      },
+      {
+        "name": "Warner TV",
+        "number": 73
+      },
+      {
+        "name": "TV Breizh",
+        "number": 74
+      },
+      {
+        "name": "RTL9",
+        "number": 75
+      },
+      {
+        "name": "AB1",
+        "number": 76
+      },
+      {
+        "name": "Novelas TV",
+        "number": 77
+      }
+    ],
+    "Sports": [
+      {
+        "name": "Infosport+",
+        "number": 93
+      },
+      {
+        "name": "beIN Sports 1",
+        "number": 96
+      },
+      {
+        "name": "beIN Sports 2",
+        "number": 97
+      },
+      {
+        "name": "beIN Sports 3",
+        "number": 98
+      },
+      {
+        "name": "Eurosport 1",
+        "number": 99
+      },
+      {
+        "name": "Eurosport 2",
+        "number": 100
+      },
+      {
+        "name": "Golf+",
+        "number": 102
+      },
+      {
+        "name": "Automoto",
+        "number": 103
+      },
+      {
+        "name": "Equidia",
+        "number": 104
+      },
+      {
+        "name": "Sport en France",
+        "number": 105
+      },
+      {
+        "name": "Cheval TV",
+        "number": 106
+      }
+    ],
+    "Divertissement": [
+      {
+        "name": "Comédie+",
+        "number": 110
+      },
+      {
+        "name": "Olympia TV",
+        "number": 111
+      },
+      {
+        "name": "Paris Première",
+        "number": 112
+      },
+      {
+        "name": "Teva",
+        "number": 113
+      },
+      {
+        "name": "TLC",
+        "number": 115
+      },
+      {
+        "name": "TV5 Monde",
+        "number": 116
+      }
+    ],
+    "Découverte": [
+      {
+        "name": "Planète+",
+        "number": 121
+      },
+      {
+        "name": "Planète+Crime",
+        "number": 122
+      },
+      {
+        "name": "Planète+Aventure",
+        "number": 123
+      },
+      {
+        "name": "Museum TV",
+        "number": 124
+      },
+      {
+        "name": "Ushuaïa TV",
+        "number": 126
+      },
+      {
+        "name": "Love Nature",
+        "number": 127
+      },
+      {
+        "name": "Histoire TV",
+        "number": 128
+      },
+      {
+        "name": "Toute l'Histoire",
+        "number": 129
+      },
+      {
+        "name": "Discovery Channel",
+        "number": 130
+      },
+      {
+        "name": "Discovery Investigation",
+        "number": 131
+      },
+      {
+        "name": "Dog & Cat TV",
+        "number": 132
+      },
+      {
+        "name": "Seasons",
+        "number": 133
+      },
+      {
+        "name": "Chasse et Pêche",
+        "number": 134
+      },
+      {
+        "name": "Animaux",
+        "number": 135
+      },
+      {
+        "name": "TV Monaco",
+        "number": 136
+      },
+      {
+        "name": "Le Figaro TV",
+        "number": 137
+      },
+      {
+        "name": "8 Mont Blanc",
+        "number": 138
+      },
+      {
+        "name": "Mieux",
+        "number": 139
+      }
+    ],
+    "Jeunesse": [
+      {
+        "name": "Piwi+",
+        "number": 141
+      },
+      {
+        "name": "Nickelodeon Junior",
+        "number": 143
+      },
+      {
+        "name": "Tiji",
+        "number": 144
+      },
+      {
+        "name": "Cartoonito",
+        "number": 145
+      },
+      {
+        "name": "Boomerang",
+        "number": 146
+      },
+      {
+        "name": "Teletoon+",
+        "number": 147
+      },
+      {
+        "name": "Teletoon+1",
+        "number": 148
+      },
+      {
+        "name": "Disney Channel",
+        "number": 149
+      },
+      {
+        "name": "Cartoon Network",
+        "number": 151
+      },
+      {
+        "name": "Nickelodeon",
+        "number": 152
+      },
+      {
+        "name": "Nickelodeon+1",
+        "number": 153
+      },
+      {
+        "name": "Canal J",
+        "number": 154
+      },
+      {
+        "name": "Nicktoons",
+        "number": 156
+      }
+    ],
+    "Nouvelle Génération": [
+      {
+        "name": "MTV",
+        "number": 162
+      },
+      {
+        "name": "MCM",
+        "number": 163
+      },
+      {
+        "name": "Comedy Central",
+        "number": 164
+      },
+      {
+        "name": "Mangas",
+        "number": 166
+      },
+      {
+        "name": "MGG TV",
+        "number": 168
+      },
+      {
+        "name": "Warner TV Next",
+        "number": 169
+      }
+    ],
+    "Information": [
+      {
+        "name": "La Chaîne Météo",
+        "number": 170
+      },
+      {
+        "name": "CNews Prime",
+        "number": 171
+      },
+      {
+        "name": "Europe 1 TV",
+        "number": 172
+      },
+      {
+        "name": "France 24",
+        "number": 173
+      },
+      {
+        "name": "Euronews",
+        "number": 174
+      },
+      {
+        "name": "BBC News",
+        "number": 175
+      },
+      {
+        "name": "CNN",
+        "number": 176
+      },
+      {
+        "name": "BFM Business",
+        "number": 177
+      },
+      {
+        "name": "Bloomberg",
+        "number": 178
+      },
+      {
+        "name": "CNBC",
+        "number": 179
+      },
+      {
+        "name": "i24 News",
+        "number": 180
+      },
+      {
+        "name": "KTO",
+        "number": 181
+      },
+      {
+        "name": "Africa 24",
+        "number": 182
+      }
+    ],
+    "Musique": [
+      {
+        "name": "Europe 2 Pop TV",
+        "number": 190
+      },
+      {
+        "name": "M6 Music",
+        "number": 191
+      },
+      {
+        "name": "NRJ Hits",
+        "number": 193
+      },
+      {
+        "name": "Trace Urban",
+        "number": 194
+      },
+      {
+        "name": "RFM TV",
+        "number": 196
+      },
+      {
+        "name": "Mélody",
+        "number": 198
+      },
+      {
+        "name": "Mezzo",
+        "number": 200
+      },
+      {
+        "name": "Mezzo Live HD",
+        "number": 201
+      },
+      {
+        "name": "Deutsche Grammophon+",
+        "number": 202
+      }
+    ],
+    "Charme": [
+      {
+        "name": "XXL",
+        "number": 222
+      },
+      {
+        "name": "Dorcel TV",
+        "number": 223
+      },
+      {
+        "name": "Dorcel XXX",
+        "number": 224
+      },
+      {
+        "name": "Vixen",
+        "number": 225
+      },
+      {
+        "name": "UnionTV",
+        "number": 226
+      },
+      {
+        "name": "Pink X",
+        "number": 228
+      },
+      {
+        "name": "Man-X",
+        "number": 229
+      }
+    ],
+    "Canal+ Live": [
+      {
+        "name": "Canal+ Live 1",
+        "number": 231
+      },
+      {
+        "name": "Canal+ Live 2",
+        "number": 232
+      },
+      {
+        "name": "Canal+ Live 3",
+        "number": 233
+      },
+      {
+        "name": "Canal+ Live 4",
+        "number": 234
+      },
+      {
+        "name": "Canal+ Live 5",
+        "number": 235
+      },
+      {
+        "name": "Canal+ Live 6",
+        "number": 236
+      },
+      {
+        "name": "Canal+ Live 7",
+        "number": 237
+      },
+      {
+        "name": "Canal+ Live 8",
+        "number": 238
+      },
+      {
+        "name": "Canal+ Live 9",
+        "number": 239
+      },
+      {
+        "name": "Canal+ Live 10",
+        "number": 240
+      },
+      {
+        "name": "Canal+ Live 11",
+        "number": 241
+      },
+      {
+        "name": "Canal+ Live 12",
+        "number": 242
+      },
+      {
+        "name": "Canal+ Live 13",
+        "number": 243
+      },
+      {
+        "name": "Canal+ Live 14",
+        "number": 244
+      },
+      {
+        "name": "Canal+ Live 15",
+        "number": 245
+      },
+      {
+        "name": "Canal+ Live 16",
+        "number": 246
+      },
+      {
+        "name": "Canal+ Live 17",
+        "number": 247
+      },
+      {
+        "name": "Canal+ Live 18",
+        "number": 248
+      },
+      {
+        "name": "Canal+ Live 19",
+        "number": 249
+      },
+      {
+        "name": "Canal+ Premier League",
+        "number": 250
+      }
+    ],
+    "Sports Multi-Diffusion": [
+      {
+        "name": "Eurosport 360 1",
+        "number": 252
+      },
+      {
+        "name": "Eurosport 360 2",
+        "number": 253
+      },
+      {
+        "name": "Eurosport 360 3",
+        "number": 254
+      },
+      {
+        "name": "Eurosport 360 4",
+        "number": 255
+      },
+      {
+        "name": "Eurosport 360 5",
+        "number": 256
+      },
+      {
+        "name": "Eurosport 360 6",
+        "number": 257
+      },
+      {
+        "name": "Eurosport 360 7",
+        "number": 258
+      },
+      {
+        "name": "Eurosport 360 8",
+        "number": 259
+      },
+      {
+        "name": "Eurosport 360 9",
+        "number": 260
+      },
+      {
+        "name": "Eurosport 360 10",
+        "number": 261
+      },
+      {
+        "name": "Eurosport 360 11",
+        "number": 262
+      },
+      {
+        "name": "Eurosport 360 12",
+        "number": 263
+      },
+      {
+        "name": "Eurosport 360 13",
+        "number": 264
+      },
+      {
+        "name": "Eurosport 360 14",
+        "number": 265
+      },
+      {
+        "name": "Eurosport 360 15",
+        "number": 266
+      },
+      {
+        "name": "Eurosport 360 16",
+        "number": 267
+      },
+      {
+        "name": "Eurosport 360 17",
+        "number": 268
+      },
+      {
+        "name": "Eurosport 360 18",
+        "number": 269
+      },
+      {
+        "name": "Eurosport 360 19",
+        "number": 270
+      },
+      {
+        "name": "Eurosport 360 20",
+        "number": 271
+      },
+      {
+        "name": "Eurosport 360 21",
+        "number": 272
+      },
+      {
+        "name": "Eurosport 360 22",
+        "number": 273
+      },
+      {
+        "name": "Eurosport 360 23",
+        "number": 274
+      },
+      {
+        "name": "Eurosport 360 24",
+        "number": 275
+      },
+      {
+        "name": "Eurosport 360 25",
+        "number": 276
+      },
+      {
+        "name": "Eurosport 360 26",
+        "number": 277
+      },
+      {
+        "name": "Eurosport 360 27",
+        "number": 278
+      },
+      {
+        "name": "Eurosport 360 28",
+        "number": 279
+      },
+      {
+        "name": "Eurosport 360 29",
+        "number": 280
+      },
+      {
+        "name": "Eurosport 360 30",
+        "number": 281
+      },
+      {
+        "name": "Eurosport 360 31",
+        "number": 282
+      },
+      {
+        "name": "Eurosport 360 32",
+        "number": 283
+      },
+      {
+        "name": "beIN Sports MAX 4",
+        "number": 284
+      },
+      {
+        "name": "beIN Sports MAX 5",
+        "number": 285
+      },
+      {
+        "name": "beIN Sports MAX 6",
+        "number": 286
+      },
+      {
+        "name": "beIN Sports MAX 7",
+        "number": 287
+      },
+      {
+        "name": "beIN Sports MAX 8",
+        "number": 288
+      },
+      {
+        "name": "beIN Sports MAX 9",
+        "number": 289
+      },
+      {
+        "name": "beIN Sports MAX 10",
+        "number": 290
+      },
+      {
+        "name": "RMC Sport 1",
+        "number": 291
+      },
+      {
+        "name": "Ligue 1+ 1",
+        "number": 292
+      },
+      {
+        "name": "Ligue 1+ 2",
+        "number": 293
+      },
+      {
+        "name": "Ligue 1+ 3",
+        "number": 294
+      },
+      {
+        "name": "Ligue 1+ 4",
+        "number": 295
+      },
+      {
+        "name": "Ligue 1+ 5",
+        "number": 296
+      },
+      {
+        "name": "Ligue 1+ 6",
+        "number": 297
+      },
+      {
+        "name": "Ligue 1+ 7",
+        "number": 298
+      },
+      {
+        "name": "Ligue 1+ 8",
+        "number": 299
+      },
+      {
+        "name": "Ligue 1+ 9",
+        "number": 300
+      },
+      {
+        "name": "Ligue 1+ 10",
+        "number": 301
+      }
+    ],
+    "DOM-TOM": [
+      {
+        "name": "Martinique la 1ère",
+        "number": 337
+      },
+      {
+        "name": "Guadeloupe la 1ère",
+        "number": 338
+      },
+      {
+        "name": "Réunion la 1ère",
+        "number": 339
+      },
+      {
+        "name": "Mayotte la 1ère",
+        "number": 340
+      },
+      {
+        "name": "Guyane la 1ère",
+        "number": 341
+      }
+    ],
+    "BFM Régionales": [
+      {
+        "name": "BFM Paris",
+        "number": 326
+      },
+      {
+        "name": "BFM Grand Lille",
+        "number": 327
+      },
+      {
+        "name": "BFM Grand Littoral",
+        "number": 328
+      },
+      {
+        "name": "BFM Normandie",
+        "number": 329
+      },
+      {
+        "name": "BFM Alsace",
+        "number": 330
+      },
+      {
+        "name": "BFM Lyon",
+        "number": 331
+      },
+      {
+        "name": "BFM Alpes Sud",
+        "number": 332
+      },
+      {
+        "name": "BFM Marseille Provence",
+        "number": 333
+      },
+      {
+        "name": "BFM Toulon Var",
+        "number": 334
+      },
+      {
+        "name": "BFM Côte d'Azur",
+        "number": 335
+      },
+      {
+        "name": "BFM Haute-Provence",
+        "number": 336
+      }
+    ],
+    "Via Occitanie": [
+      {
+        "name": "Via Occitanie Montpellier",
+        "number": 342
+      },
+      {
+        "name": "Via Occitanie Toulouse",
+        "number": 343
+      },
+      {
+        "name": "Via Occitanie Pays Catalan",
+        "number": 344
+      },
+      {
+        "name": "Via Occitanie Pays Gardois",
+        "number": 345
+      }
+    ],
+    "France 3 Régions": [
+      {
+        "name": "France 3 Alpes",
+        "number": 350
+      },
+      {
+        "name": "France 3 Alsace",
+        "number": 351
+      },
+      {
+        "name": "France 3 Aquitaine",
+        "number": 352
+      },
+      {
+        "name": "France 3 Auvergne",
+        "number": 353
+      },
+      {
+        "name": "France 3 Basse-Normandie",
+        "number": 354
+      },
+      {
+        "name": "France 3 Bourgogne",
+        "number": 355
+      },
+      {
+        "name": "France 3 Bretagne",
+        "number": 356
+      },
+      {
+        "name": "France 3 Centre-Val de Loire",
+        "number": 357
+      },
+      {
+        "name": "France 3 Champagne-Ardenne",
+        "number": 358
+      },
+      {
+        "name": "France 3 Via Stella",
+        "number": 359
+      },
+      {
+        "name": "France 3 Côte d'Azur",
+        "number": 360
+      },
+      {
+        "name": "France 3 Franche-Comté",
+        "number": 361
+      },
+      {
+        "name": "France 3 Haute-Normandie",
+        "number": 362
+      },
+      {
+        "name": "France 3 Languedoc-Roussillon",
+        "number": 363
+      },
+      {
+        "name": "France 3 Limousin",
+        "number": 364
+      },
+      {
+        "name": "France 3 Lorraine",
+        "number": 365
+      },
+      {
+        "name": "France 3 Midi-Pyrénées",
+        "number": 366
+      },
+      {
+        "name": "France 3 Nord-Pas-de-Calais",
+        "number": 367
+      },
+      {
+        "name": "France 3 Paris Île-de-France",
+        "number": 368
+      },
+      {
+        "name": "France 3 Pays de la Loire",
+        "number": 369
+      },
+      {
+        "name": "France 3 Picardie",
+        "number": 370
+      },
+      {
+        "name": "France 3 Poitou-Charentes",
+        "number": 371
+      },
+      {
+        "name": "France 3 Provence-Alpes",
+        "number": 372
+      },
+      {
+        "name": "France 3 Rhône-Alpes",
+        "number": 373
+      },
+      {
+        "name": "France 3 NoA",
+        "number": 374
+      }
+    ],
+    "International": [
+      {
+        "name": "A+",
+        "number": 378
+      },
+      {
+        "name": "A+ Bénin",
+        "number": 379
+      },
+      {
+        "name": "A+ Ivoire",
+        "number": 380
+      },
+      {
+        "name": "Nollywood TV",
+        "number": 381
+      },
+      {
+        "name": "Nollywood TV Epic",
+        "number": 382
+      },
+      {
+        "name": "Sunu Yeuf",
+        "number": 383
+      },
+      {
+        "name": "Pulaagu",
+        "number": 384
+      },
+      {
+        "name": "Mandeka",
+        "number": 385
+      },
+      {
+        "name": "Maboke TV",
+        "number": 386
+      },
+      {
+        "name": "Canal+ Magic",
+        "number": 387
+      },
+      {
+        "name": "2M Monde",
+        "number": 388
+      },
+      {
+        "name": "Echorouk News",
+        "number": 389
+      },
+      {
+        "name": "Echourouk TV",
+        "number": 390
+      },
+      {
+        "name": "Nessma TV",
+        "number": 391
+      },
+      {
+        "name": "Samira TV",
+        "number": 392
+      },
+      {
+        "name": "El Hiwar Ettounsi",
+        "number": 393
+      },
+      {
+        "name": "Sky News Arabia",
+        "number": 394
+      },
+      {
+        "name": "MBC 5",
+        "number": 395
+      },
+      {
+        "name": "MBC Drama",
+        "number": 396
+      },
+      {
+        "name": "Rotana Cinéma FR",
+        "number": 397
+      },
+      {
+        "name": "Rotana Cinéma",
+        "number": 398
+      },
+      {
+        "name": "Rotana Kids",
+        "number": 399
+      }
+    ]
+  }
+}

--- a/Lineuparr/FR_CanalPlus_lineup.json
+++ b/Lineuparr/FR_CanalPlus_lineup.json
@@ -1,0 +1,1139 @@
+{
+  "package": "Canal+ France (Numérotation Canal+)",
+  "date": "2026-06-01",
+  "description": "Chaînes Canal+ France avec numérotation Canal+, en vigueur à compter du 30 mars 2026",
+  "source": "Canal+ Plan de Service Canal+ 2026",
+  "notes": "Numérotation Canal+ utilisée sur les décodeurs Canal+ en France métropolitaine. Les flux en direct (Canal+ Live, Eurosport 360), les services à la demande (VOD, Netflix, etc.) et les mosaïques ne sont pas inclus.",
+  "categories": {
+    "Canal+ & Grandes Chaînes": [
+      {
+        "name": "Chaîne Événement",
+        "number": 29
+      },
+      {
+        "name": "TF1",
+        "number": 1
+      },
+      {
+        "name": "France 2",
+        "number": 2
+      },
+      {
+        "name": "France 3",
+        "number": 3
+      },
+      {
+        "name": "Canal+",
+        "number": 4
+      },
+      {
+        "name": "France 5",
+        "number": 5
+      },
+      {
+        "name": "M6",
+        "number": 6
+      },
+      {
+        "name": "Arte",
+        "number": 7
+      },
+      {
+        "name": "Canal+Sport 360",
+        "number": 10
+      },
+      {
+        "name": "Canal+Foot",
+        "number": 11
+      },
+      {
+        "name": "Canal+Sport",
+        "number": 12
+      },
+      {
+        "name": "Canal+Box Office",
+        "number": 13
+      },
+      {
+        "name": "Canal+Grand Écran",
+        "number": 14
+      },
+      {
+        "name": "Canal+Cinéma(s)",
+        "number": 15
+      },
+      {
+        "name": "Canal+Docs",
+        "number": 17
+      },
+      {
+        "name": "Canal+Kids",
+        "number": 18
+      }
+    ],
+    "UHD": [
+      {
+        "name": "Canal+ UHD",
+        "number": 100
+      },
+      {
+        "name": "Événement Sport UHD",
+        "number": 101
+      },
+      {
+        "name": "France 2 UHD",
+        "number": 102
+      }
+    ],
+    "Cinéma": [
+      {
+        "name": "OCS",
+        "number": 33
+      },
+      {
+        "name": "Ciné+ Frisson",
+        "number": 34
+      },
+      {
+        "name": "Ciné+ Émotion",
+        "number": 35
+      },
+      {
+        "name": "Ciné+ Family",
+        "number": 36
+      },
+      {
+        "name": "Ciné+ Festival",
+        "number": 37
+      },
+      {
+        "name": "Ciné+ Classic",
+        "number": 38
+      },
+      {
+        "name": "Action",
+        "number": 44
+      },
+      {
+        "name": "TCM Cinéma",
+        "number": 45
+      }
+    ],
+    "Séries": [
+      {
+        "name": "Polar+",
+        "number": 51
+      },
+      {
+        "name": "Serieclub",
+        "number": 52
+      },
+      {
+        "name": "Warner TV",
+        "number": 53
+      },
+      {
+        "name": "TV Breizh",
+        "number": 54
+      },
+      {
+        "name": "RTL9",
+        "number": 55
+      },
+      {
+        "name": "AB1",
+        "number": 56
+      },
+      {
+        "name": "Novelas TV",
+        "number": 57
+      },
+      {
+        "name": "TF1 Séries Films",
+        "number": 59
+      }
+    ],
+    "Sports": [
+      {
+        "name": "Infosport+",
+        "number": 63
+      },
+      {
+        "name": "beIN Sports 1",
+        "number": 66
+      },
+      {
+        "name": "beIN Sports 2",
+        "number": 67
+      },
+      {
+        "name": "beIN Sports 3",
+        "number": 68
+      },
+      {
+        "name": "Eurosport 1",
+        "number": 69
+      },
+      {
+        "name": "Eurosport 2",
+        "number": 70
+      },
+      {
+        "name": "Golf+",
+        "number": 72
+      },
+      {
+        "name": "Automoto",
+        "number": 73
+      },
+      {
+        "name": "Equidia",
+        "number": 74
+      },
+      {
+        "name": "Sport en France",
+        "number": 75
+      },
+      {
+        "name": "Cheval TV",
+        "number": 76
+      },
+      {
+        "name": "L'Équipe",
+        "number": 79
+      }
+    ],
+    "Divertissement": [
+      {
+        "name": "Comédie+",
+        "number": 80
+      },
+      {
+        "name": "Olympia TV",
+        "number": 81
+      },
+      {
+        "name": "Paris Première",
+        "number": 83
+      },
+      {
+        "name": "Teva",
+        "number": 84
+      },
+      {
+        "name": "TLC",
+        "number": 86
+      },
+      {
+        "name": "W9",
+        "number": 89
+      },
+      {
+        "name": "TMC",
+        "number": 90
+      },
+      {
+        "name": "TFX",
+        "number": 91
+      },
+      {
+        "name": "CSTAR",
+        "number": 92
+      },
+      {
+        "name": "T18",
+        "number": 93
+      },
+      {
+        "name": "Novo19",
+        "number": 94
+      },
+      {
+        "name": "6ter",
+        "number": 95
+      },
+      {
+        "name": "RMC Story",
+        "number": 96
+      },
+      {
+        "name": "RMC Life",
+        "number": 97
+      },
+      {
+        "name": "TV5 Monde",
+        "number": 98
+      }
+    ],
+    "Découverte": [
+      {
+        "name": "Planète+",
+        "number": 111
+      },
+      {
+        "name": "Planète+Crime",
+        "number": 112
+      },
+      {
+        "name": "Planète+Aventure",
+        "number": 113
+      },
+      {
+        "name": "Museum TV",
+        "number": 114
+      },
+      {
+        "name": "Ushuaïa TV",
+        "number": 115
+      },
+      {
+        "name": "Love Nature",
+        "number": 116
+      },
+      {
+        "name": "Histoire TV",
+        "number": 117
+      },
+      {
+        "name": "Toute l'Histoire",
+        "number": 118
+      },
+      {
+        "name": "Discovery Channel",
+        "number": 119
+      },
+      {
+        "name": "Discovery Investigation",
+        "number": 120
+      },
+      {
+        "name": "Dog & Cat TV",
+        "number": 121
+      },
+      {
+        "name": "Seasons",
+        "number": 122
+      },
+      {
+        "name": "Chasse et Pêche",
+        "number": 123
+      },
+      {
+        "name": "Animaux",
+        "number": 124
+      },
+      {
+        "name": "TV Monaco",
+        "number": 125
+      },
+      {
+        "name": "Le Figaro TV",
+        "number": 126
+      },
+      {
+        "name": "8 Mont Blanc",
+        "number": 127
+      },
+      {
+        "name": "Mieux",
+        "number": 128
+      },
+      {
+        "name": "RMC Découverte",
+        "number": 129
+      }
+    ],
+    "Jeunesse": [
+      {
+        "name": "Piwi+",
+        "number": 131
+      },
+      {
+        "name": "Nickelodeon Junior",
+        "number": 133
+      },
+      {
+        "name": "Tiji",
+        "number": 134
+      },
+      {
+        "name": "Cartoonito",
+        "number": 135
+      },
+      {
+        "name": "Boomerang",
+        "number": 136
+      },
+      {
+        "name": "Teletoon+",
+        "number": 137
+      },
+      {
+        "name": "Teletoon+1",
+        "number": 138
+      },
+      {
+        "name": "Disney Channel",
+        "number": 139
+      },
+      {
+        "name": "Cartoon Network",
+        "number": 141
+      },
+      {
+        "name": "Nickelodeon",
+        "number": 142
+      },
+      {
+        "name": "Nickelodeon+1",
+        "number": 143
+      },
+      {
+        "name": "Canal J",
+        "number": 144
+      },
+      {
+        "name": "Nicktoons",
+        "number": 146
+      },
+      {
+        "name": "France 4",
+        "number": 147
+      },
+      {
+        "name": "Gulli",
+        "number": 148
+      }
+    ],
+    "Nouvelle Génération": [
+      {
+        "name": "MTV",
+        "number": 152
+      },
+      {
+        "name": "MCM",
+        "number": 153
+      },
+      {
+        "name": "Comedy Central",
+        "number": 154
+      },
+      {
+        "name": "Mangas",
+        "number": 156
+      },
+      {
+        "name": "MGG TV",
+        "number": 158
+      },
+      {
+        "name": "Warner TV Next",
+        "number": 159
+      }
+    ],
+    "Information": [
+      {
+        "name": "La Chaîne Météo",
+        "number": 160
+      },
+      {
+        "name": "CNews",
+        "number": 161
+      },
+      {
+        "name": "BFM TV",
+        "number": 162
+      },
+      {
+        "name": "LCI",
+        "number": 163
+      },
+      {
+        "name": "France Info",
+        "number": 164
+      },
+      {
+        "name": "LCP",
+        "number": 165
+      },
+      {
+        "name": "CNews Prime",
+        "number": 166
+      },
+      {
+        "name": "Europe 1 TV",
+        "number": 167
+      },
+      {
+        "name": "France 24",
+        "number": 168
+      },
+      {
+        "name": "Euronews",
+        "number": 169
+      },
+      {
+        "name": "BBC News",
+        "number": 170
+      },
+      {
+        "name": "CNN",
+        "number": 171
+      },
+      {
+        "name": "BFM Business",
+        "number": 172
+      },
+      {
+        "name": "Bloomberg",
+        "number": 173
+      },
+      {
+        "name": "CNBC",
+        "number": 174
+      },
+      {
+        "name": "i24 News",
+        "number": 175
+      },
+      {
+        "name": "KTO",
+        "number": 176
+      },
+      {
+        "name": "Africa 24",
+        "number": 177
+      }
+    ],
+    "Musique": [
+      {
+        "name": "Europe 2 Pop TV",
+        "number": 180
+      },
+      {
+        "name": "M6 Music",
+        "number": 181
+      },
+      {
+        "name": "NRJ Hits",
+        "number": 183
+      },
+      {
+        "name": "Trace Urban",
+        "number": 184
+      },
+      {
+        "name": "RFM TV",
+        "number": 186
+      },
+      {
+        "name": "Mélody",
+        "number": 188
+      },
+      {
+        "name": "Mezzo",
+        "number": 200
+      },
+      {
+        "name": "Mezzo Live HD",
+        "number": 201
+      },
+      {
+        "name": "Deutsche Grammophon+",
+        "number": 202
+      }
+    ],
+    "Charme": [
+      {
+        "name": "XXL",
+        "number": 222
+      },
+      {
+        "name": "Dorcel TV",
+        "number": 223
+      },
+      {
+        "name": "Dorcel XXX",
+        "number": 224
+      },
+      {
+        "name": "Vixen",
+        "number": 225
+      },
+      {
+        "name": "UnionTV",
+        "number": 226
+      },
+      {
+        "name": "Pink X",
+        "number": 228
+      },
+      {
+        "name": "Man-X",
+        "number": 229
+      }
+    ],
+    "Canal+ Live": [
+      {
+        "name": "Canal+ Live 1",
+        "number": 231
+      },
+      {
+        "name": "Canal+ Live 2",
+        "number": 232
+      },
+      {
+        "name": "Canal+ Live 3",
+        "number": 233
+      },
+      {
+        "name": "Canal+ Live 4",
+        "number": 234
+      },
+      {
+        "name": "Canal+ Live 5",
+        "number": 235
+      },
+      {
+        "name": "Canal+ Live 6",
+        "number": 236
+      },
+      {
+        "name": "Canal+ Live 7",
+        "number": 237
+      },
+      {
+        "name": "Canal+ Live 8",
+        "number": 238
+      },
+      {
+        "name": "Canal+ Live 9",
+        "number": 239
+      },
+      {
+        "name": "Canal+ Live 10",
+        "number": 240
+      },
+      {
+        "name": "Canal+ Live 11",
+        "number": 241
+      },
+      {
+        "name": "Canal+ Live 12",
+        "number": 242
+      },
+      {
+        "name": "Canal+ Live 13",
+        "number": 243
+      },
+      {
+        "name": "Canal+ Live 14",
+        "number": 244
+      },
+      {
+        "name": "Canal+ Live 15",
+        "number": 245
+      },
+      {
+        "name": "Canal+ Live 16",
+        "number": 246
+      },
+      {
+        "name": "Canal+ Live 17",
+        "number": 247
+      },
+      {
+        "name": "Canal+ Live 18",
+        "number": 248
+      },
+      {
+        "name": "Canal+ Live 19",
+        "number": 249
+      },
+      {
+        "name": "Canal+ Premier League",
+        "number": 250
+      }
+    ],
+    "Sports Multi-Diffusion": [
+      {
+        "name": "Eurosport 360 1",
+        "number": 252
+      },
+      {
+        "name": "Eurosport 360 2",
+        "number": 253
+      },
+      {
+        "name": "Eurosport 360 3",
+        "number": 254
+      },
+      {
+        "name": "Eurosport 360 4",
+        "number": 255
+      },
+      {
+        "name": "Eurosport 360 5",
+        "number": 256
+      },
+      {
+        "name": "Eurosport 360 6",
+        "number": 257
+      },
+      {
+        "name": "Eurosport 360 7",
+        "number": 258
+      },
+      {
+        "name": "Eurosport 360 8",
+        "number": 259
+      },
+      {
+        "name": "Eurosport 360 9",
+        "number": 260
+      },
+      {
+        "name": "Eurosport 360 10",
+        "number": 261
+      },
+      {
+        "name": "Eurosport 360 11",
+        "number": 262
+      },
+      {
+        "name": "Eurosport 360 12",
+        "number": 263
+      },
+      {
+        "name": "Eurosport 360 13",
+        "number": 264
+      },
+      {
+        "name": "Eurosport 360 14",
+        "number": 265
+      },
+      {
+        "name": "Eurosport 360 15",
+        "number": 266
+      },
+      {
+        "name": "Eurosport 360 16",
+        "number": 267
+      },
+      {
+        "name": "Eurosport 360 17",
+        "number": 268
+      },
+      {
+        "name": "Eurosport 360 18",
+        "number": 269
+      },
+      {
+        "name": "Eurosport 360 19",
+        "number": 270
+      },
+      {
+        "name": "Eurosport 360 20",
+        "number": 271
+      },
+      {
+        "name": "Eurosport 360 21",
+        "number": 272
+      },
+      {
+        "name": "Eurosport 360 22",
+        "number": 273
+      },
+      {
+        "name": "Eurosport 360 23",
+        "number": 274
+      },
+      {
+        "name": "Eurosport 360 24",
+        "number": 275
+      },
+      {
+        "name": "Eurosport 360 25",
+        "number": 276
+      },
+      {
+        "name": "Eurosport 360 26",
+        "number": 277
+      },
+      {
+        "name": "Eurosport 360 27",
+        "number": 278
+      },
+      {
+        "name": "Eurosport 360 28",
+        "number": 279
+      },
+      {
+        "name": "Eurosport 360 29",
+        "number": 280
+      },
+      {
+        "name": "Eurosport 360 30",
+        "number": 281
+      },
+      {
+        "name": "Eurosport 360 31",
+        "number": 282
+      },
+      {
+        "name": "Eurosport 360 32",
+        "number": 283
+      },
+      {
+        "name": "beIN Sports MAX 4",
+        "number": 284
+      },
+      {
+        "name": "beIN Sports MAX 5",
+        "number": 285
+      },
+      {
+        "name": "beIN Sports MAX 6",
+        "number": 286
+      },
+      {
+        "name": "beIN Sports MAX 7",
+        "number": 287
+      },
+      {
+        "name": "beIN Sports MAX 8",
+        "number": 288
+      },
+      {
+        "name": "beIN Sports MAX 9",
+        "number": 289
+      },
+      {
+        "name": "beIN Sports MAX 10",
+        "number": 290
+      },
+      {
+        "name": "RMC Sport 1",
+        "number": 291
+      },
+      {
+        "name": "Ligue 1+ 1",
+        "number": 292
+      },
+      {
+        "name": "Ligue 1+ 2",
+        "number": 293
+      },
+      {
+        "name": "Ligue 1+ 3",
+        "number": 294
+      },
+      {
+        "name": "Ligue 1+ 4",
+        "number": 295
+      },
+      {
+        "name": "Ligue 1+ 5",
+        "number": 296
+      },
+      {
+        "name": "Ligue 1+ 6",
+        "number": 297
+      },
+      {
+        "name": "Ligue 1+ 7",
+        "number": 298
+      },
+      {
+        "name": "Ligue 1+ 8",
+        "number": 299
+      },
+      {
+        "name": "Ligue 1+ 9",
+        "number": 300
+      },
+      {
+        "name": "Ligue 1+ 10",
+        "number": 301
+      }
+    ],
+    "DOM-TOM": [
+      {
+        "name": "Martinique la 1ère",
+        "number": 337
+      },
+      {
+        "name": "Guadeloupe la 1ère",
+        "number": 338
+      },
+      {
+        "name": "Réunion la 1ère",
+        "number": 339
+      },
+      {
+        "name": "Mayotte la 1ère",
+        "number": 340
+      },
+      {
+        "name": "Guyane la 1ère",
+        "number": 341
+      }
+    ],
+    "BFM Régionales": [
+      {
+        "name": "BFM Paris",
+        "number": 326
+      },
+      {
+        "name": "BFM Grand Lille",
+        "number": 327
+      },
+      {
+        "name": "BFM Grand Littoral",
+        "number": 328
+      },
+      {
+        "name": "BFM Normandie",
+        "number": 329
+      },
+      {
+        "name": "BFM Alsace",
+        "number": 330
+      },
+      {
+        "name": "BFM Lyon",
+        "number": 331
+      },
+      {
+        "name": "BFM Alpes Sud",
+        "number": 332
+      },
+      {
+        "name": "BFM Marseille Provence",
+        "number": 333
+      },
+      {
+        "name": "BFM Toulon Var",
+        "number": 334
+      },
+      {
+        "name": "BFM Côte d'Azur",
+        "number": 335
+      },
+      {
+        "name": "BFM Haute-Provence",
+        "number": 336
+      }
+    ],
+    "Via Occitanie": [
+      {
+        "name": "Via Occitanie Montpellier",
+        "number": 342
+      },
+      {
+        "name": "Via Occitanie Toulouse",
+        "number": 343
+      },
+      {
+        "name": "Via Occitanie Pays Catalan",
+        "number": 344
+      },
+      {
+        "name": "Via Occitanie Pays Gardois",
+        "number": 345
+      }
+    ],
+    "France 3 Régions": [
+      {
+        "name": "France 3 Alpes",
+        "number": 350
+      },
+      {
+        "name": "France 3 Alsace",
+        "number": 351
+      },
+      {
+        "name": "France 3 Aquitaine",
+        "number": 352
+      },
+      {
+        "name": "France 3 Auvergne",
+        "number": 353
+      },
+      {
+        "name": "France 3 Basse-Normandie",
+        "number": 354
+      },
+      {
+        "name": "France 3 Bourgogne",
+        "number": 355
+      },
+      {
+        "name": "France 3 Bretagne",
+        "number": 356
+      },
+      {
+        "name": "France 3 Centre-Val de Loire",
+        "number": 357
+      },
+      {
+        "name": "France 3 Champagne-Ardenne",
+        "number": 358
+      },
+      {
+        "name": "France 3 Via Stella",
+        "number": 359
+      },
+      {
+        "name": "France 3 Côte d'Azur",
+        "number": 360
+      },
+      {
+        "name": "France 3 Franche-Comté",
+        "number": 361
+      },
+      {
+        "name": "France 3 Haute-Normandie",
+        "number": 362
+      },
+      {
+        "name": "France 3 Languedoc-Roussillon",
+        "number": 363
+      },
+      {
+        "name": "France 3 Limousin",
+        "number": 364
+      },
+      {
+        "name": "France 3 Lorraine",
+        "number": 365
+      },
+      {
+        "name": "France 3 Midi-Pyrénées",
+        "number": 366
+      },
+      {
+        "name": "France 3 Nord-Pas-de-Calais",
+        "number": 367
+      },
+      {
+        "name": "France 3 Paris Île-de-France",
+        "number": 368
+      },
+      {
+        "name": "France 3 Pays de la Loire",
+        "number": 369
+      },
+      {
+        "name": "France 3 Picardie",
+        "number": 370
+      },
+      {
+        "name": "France 3 Poitou-Charentes",
+        "number": 371
+      },
+      {
+        "name": "France 3 Provence-Alpes",
+        "number": 372
+      },
+      {
+        "name": "France 3 Rhône-Alpes",
+        "number": 373
+      },
+      {
+        "name": "France 3 NoA",
+        "number": 374
+      }
+    ],
+    "International": [
+      {
+        "name": "A+",
+        "number": 378
+      },
+      {
+        "name": "A+ Bénin",
+        "number": 379
+      },
+      {
+        "name": "A+ Ivoire",
+        "number": 380
+      },
+      {
+        "name": "Nollywood TV",
+        "number": 381
+      },
+      {
+        "name": "Nollywood TV Epic",
+        "number": 382
+      },
+      {
+        "name": "Sunu Yeuf",
+        "number": 383
+      },
+      {
+        "name": "Pulaagu",
+        "number": 384
+      },
+      {
+        "name": "Mandeka",
+        "number": 385
+      },
+      {
+        "name": "Maboke TV",
+        "number": 386
+      },
+      {
+        "name": "Canal+ Magic",
+        "number": 387
+      },
+      {
+        "name": "2M Monde",
+        "number": 388
+      },
+      {
+        "name": "Echorouk News",
+        "number": 389
+      },
+      {
+        "name": "Echourouk TV",
+        "number": 390
+      },
+      {
+        "name": "Nessma TV",
+        "number": 391
+      },
+      {
+        "name": "Samira TV",
+        "number": 392
+      },
+      {
+        "name": "El Hiwar Ettounsi",
+        "number": 393
+      },
+      {
+        "name": "Sky News Arabia",
+        "number": 394
+      },
+      {
+        "name": "MBC 5",
+        "number": 395
+      },
+      {
+        "name": "MBC Drama",
+        "number": 396
+      },
+      {
+        "name": "Rotana Cinéma FR",
+        "number": 397
+      },
+      {
+        "name": "Rotana Cinéma",
+        "number": 398
+      },
+      {
+        "name": "Rotana Kids",
+        "number": 399
+      }
+    ]
+  }
+}

--- a/Lineuparr/aliases.py
+++ b/Lineuparr/aliases.py
@@ -265,6 +265,85 @@ CHANNEL_ALIASES = {
     "Home": ["U&Home", "U&Home HD", "Home"],
     "Dave ja vu": ["Dave ja vu", "U&Dave ja vu"],
 
+    # --- FR: Free DTT (TNT) ---
+    "BFM TV": ["BFMTV"],
+    "CNews": ["i>TELE", "iTELE", "i-Tele"],
+    "TFX": ["NT1"],
+    "T18": ["C8"],
+    "RMC Life": ["Chérie 25"],
+    "L'Équipe": ["La Chaîne L'Équipe", "L'Equipe 21"],
+    "TF1 Séries Films": ["TF1SF"],
+    "LCP": ["LCP AN", "LCP Assemblée nationale"],
+
+    # --- FR: Divertissement ---
+    "TLC": ["Discovery Science"],
+
+    # --- FR: Canal+ Channels ---
+    "Canal+": ["Canal Plus"],
+    "Canal+Sport 360": ["Canal+ 360"],
+
+    # --- FR: Movies ---
+    "OCS": ["Ciné+ OCS", "Ciné+ Premier"],
+    "Ciné+ Festival": ["Ciné+ Club"],
+    "Ciné+ Family": ["Cine+ Famiz", "Cine+ Familly"],
+
+    # --- FR: Sports ---
+    "Equidia": ["Equidia Live"],
+    "beIN Sports 1": ["beIN Sports 1 French"],
+    "beIN Sports 2": ["beIN Sports 2 French"],
+    "beIN Sports 3": ["beIN Sports 3 French"],
+
+    # --- FR: beIN Sports MAX ---
+    "beIN Sports MAX 4": ["beIN MAX 4"],
+    "beIN Sports MAX 5": ["beIN MAX 5"],
+    "beIN Sports MAX 6": ["beIN MAX 6"],
+    "beIN Sports MAX 7": ["beIN MAX 7"],
+    "beIN Sports MAX 8": ["beIN MAX 8"],
+    "beIN Sports MAX 9": ["beIN MAX 9"],
+    "beIN Sports MAX 10": ["beIN MAX 10"],
+
+    # --- FR: RMC Sport ---
+    "RMC Sport 1": ["RMC Sport"],
+
+    # --- FR: Kids ---
+    "Cartoonito": ["Boing"],
+    "Nicktoons": ["Nickelodeon 4 Teen"],
+    "Teletoon+": ["Teletoon Plus", "Télétoon+"],
+
+    # --- FR: News ---
+    "France 24": ["FR24"],
+
+    # --- FR: Music ---
+    "Europe 2 Pop TV": ["CSTAR Hits France", "C Star Hits France"],
+    "MTV": ["MTV France"],
+
+    # --- FR: France 3 Régions ---
+    "France 3 Champagne-Ardenne": ["France 3 Champ Ardenne", "F3 Champ Ardenne"],
+    "France 3 Paris Île-de-France": ["France 3 Paris IDF", "France 3 Paris Ile de France"],
+    "France 3 Nord-Pas-de-Calais": ["France 3 Nord PDC", "France 3 Nord Pas de Calais", "France 3 Nord - Pas-de-Calais"],
+    "France 3 Côte d'Azur": ["France 3 Cote d'Azur", "F3 Cote d'Azur", "France 3 Cote D Azur"],
+    "France 3 Via Stella": ["France 3 Corse Via Stella", "France 3 Corse"],
+    "France 3 Centre-Val de Loire": ["France 3 Centre"],
+
+    # --- FR: BFM Régionales ---
+    "BFM Haute-Provence": ["BFM Haute Province", "BFM DICI Haute-Provence", "BFM Dici Haute Province"],
+    "BFM Alpes Sud": ["BFM DICI Alpes du Sud", "BFM Alpes du Sud"],
+    "BFM Marseille Provence": ["BFM Marseille", "BFM Marseille Provence"],
+    "BFM Côte d'Azur": ["BFM Cote d'Azur", "BFM Cote D Azur"],
+
+    # --- FR: Via Occitanie ---
+    "Via Occitanie Montpellier": ["Via Occitanie Monpellier"],
+
+    # --- FR: DOM-TOM 1ères ---
+    "Martinique la 1ère": ["Martinique 1ere"],
+    "Guadeloupe la 1ère": ["Guadeloupe 1ere"],
+    "Réunion la 1ère": ["Reunion 1ere"],
+    "Mayotte la 1ère": ["Mayotte 1ere"],
+    "Guyane la 1ère": ["Guyane 1ere"],
+
+    # --- FR: International ---
+    "2M Monde": ["2M"],
+
     # --- UK: Factual ---
     "Discovery History": ["Disc.History", "Disc.History+1", "UK: Discovery History"],
     "Discovery Turbo": ["Disc.Turbo", "Disc.Turbo+1", "UK: DISCOVERY TURBO", "DISCOVERY TURBO"],

--- a/Lineuparr/fuzzy_matcher.py
+++ b/Lineuparr/fuzzy_matcher.py
@@ -830,7 +830,7 @@ class FuzzyMatcher:
         return None, 0, None
 
     def match_all_streams(self, lineup_name, candidate_names, alias_map, channel_number=None,
-                          user_ignored_tags=None, lineup_country=None):
+                          user_ignored_tags=None, lineup_country=None, block_quality_streams=False):
         """
         Full matching pipeline for Lineuparr: alias → exact → substring → fuzzy, with number boost.
         Returns ALL matching streams sorted by score.
@@ -841,6 +841,8 @@ class FuzzyMatcher:
             alias_map: Alias dict
             channel_number: Expected channel number for boost
             user_ignored_tags: Tags to strip
+            block_quality_streams: When True, upgrade-quality streams (4K/8K/UHD/HDR) are
+                excluded from matching standard lineup channels (those without an upgrade marker).
 
         Returns:
             List of (stream_name, score, match_type) tuples sorted by score desc.
@@ -850,6 +852,21 @@ class FuzzyMatcher:
 
         if user_ignored_tags is None:
             user_ignored_tags = []
+
+        # Quality-aware pre-filtering (runs before alias + fuzzy stages).
+        # Rule 1 (unconditional): upgrade-declared lineup channels accept only
+        #   upgrade streams — e.g. "France 2 UHD" won't match "FR: FRANCE 2".
+        # Rule 2 (opt-in): when block_quality_streams is True, upgrade streams
+        #   are excluded from standard channels — e.g. "FR: TF1 4K" won't match
+        #   "TF1" when the option is on.
+        lineup_is_upgrade = _has_upgrade_quality(lineup_name or "")
+        if lineup_is_upgrade or block_quality_streams:
+            candidate_names = [
+                c for c in candidate_names
+                if _has_upgrade_quality(c) == lineup_is_upgrade
+            ]
+            if not candidate_names:
+                return []
 
         # Callsign anchor (asymmetric): extract the lineup channel's US
         # broadcast callsign up front. Used after the fuzzy stages to floor

--- a/Lineuparr/fuzzy_matcher.py
+++ b/Lineuparr/fuzzy_matcher.py
@@ -35,6 +35,20 @@ QUALITY_PATTERNS = [
     r'\s+\b(4K|8K|UHD|FHD|HD|HDR|HEVC|SD|FD|Unknown|Unk|Slow|Dead)\b\s+',
 ]
 
+# Upgrade quality markers for quality-aware stream filtering.
+# HD / FHD / HEVC are intentionally excluded — they are standard IPTV quality
+# and their presence does not signal a premium or event-only channel.
+_UPGRADE_QUALITY_RE = re.compile(
+    r'\b(?:4K|8K|UHD|HDR)\b|ᵁᴴᴰ',
+    re.IGNORECASE,
+)
+
+
+def _has_upgrade_quality(name: str) -> bool:
+    """Return True if name contains an upgrade quality marker (4K/8K/UHD/HDR)."""
+    return bool(_UPGRADE_QUALITY_RE.search(name))
+
+
 REGIONAL_PATTERNS = [
     # East/West are intentionally NOT stripped — they distinguish separate channel feeds
     # (e.g., "HBO East" and "HBO West" are different channels)

--- a/Lineuparr/fuzzy_matcher.py
+++ b/Lineuparr/fuzzy_matcher.py
@@ -10,7 +10,13 @@ import re
 import logging
 import unicodedata
 
-__version__ = "1.3.1"
+# Unicode categories considered decorative/badge characters by IPTV providers.
+# So = Other Symbol (◉), No = Other Number (², ³), Lm = Modifier Letter
+# (ᴿᴬᵂ, ᴴᴰ, ⱽᴵᴾ superscripts), Sk = Modifier Symbol, Sm = Math Symbol.
+# Accented letters (é, î, ü…) are Ll/Lu and are NOT in this set.
+_DECORATOR_CATS = frozenset({'So', 'No', 'Lm', 'Sk', 'Sm'})
+
+__version__ = "1.3.8"
 
 LOGGER = logging.getLogger("plugins.lineuparr.fuzzy_matcher")
 if not LOGGER.handlers:
@@ -22,11 +28,11 @@ LOGGER.setLevel(logging.DEBUG)
 # --- Pattern categories for normalization ---
 
 QUALITY_PATTERNS = [
-    r'\s*\[(4K|8K|UHD|FHD|HD|SD|FD|Unknown|Unk|Slow|Dead|Backup)\]\s*',
-    r'\s*\((4K|8K|UHD|FHD|HD|SD|FD|Unknown|Unk|Slow|Dead|Backup)\)\s*',
-    r'^\s*(4K|8K|UHD|FHD|HD|SD|FD|Unknown|Unk|Slow|Dead)\b\s*',
-    r'\s*\b(4K|8K|UHD|FHD|HD|SD|FD|Unknown|Unk|Slow|Dead)$',
-    r'\s+\b(4K|8K|UHD|FHD|HD|SD|FD|Unknown|Unk|Slow|Dead)\b\s+',
+    r'\s*\[(4K|8K|UHD|FHD|HD|HDR|HEVC|SD|FD|Unknown|Unk|Slow|Dead|Backup)\]\s*',
+    r'\s*\((4K|8K|UHD|FHD|HD|HDR|HEVC|SD|FD|Unknown|Unk|Slow|Dead|Backup)\)\s*',
+    r'^\s*(4K|8K|UHD|FHD|HD|HDR|HEVC|SD|FD|Unknown|Unk|Slow|Dead)\b\s*',
+    r'\s*\b(4K|8K|UHD|FHD|HD|HDR|HEVC|SD|FD|Unknown|Unk|Slow|Dead)$',
+    r'\s+\b(4K|8K|UHD|FHD|HD|HDR|HEVC|SD|FD|Unknown|Unk|Slow|Dead)\b\s+',
 ]
 
 REGIONAL_PATTERNS = [
@@ -59,6 +65,8 @@ PROVIDER_PREFIX_PATTERNS = [
     r'^(?:US|UK|CA|AU)\s+',
     r'^\s*\((?:US|USA|UK|CA|AU|FR|DE|ES|IT|NL|BR|MX|IN)\)\s*',
     r'\s*\|\s*(?:US|USA|UK|CA|AU|FR|DE|ES|IT|NL|BR|MX|IN)\s*$',
+    # Content-category group prefixes used by some IPTV providers.
+    r'^(?:ADULT|EROTIC|PRIME)\s*[:\-\|]\s*',
 ]
 
 MISC_PATTERNS = [
@@ -132,7 +140,7 @@ def detect_stream_country(name):
     if m:
         return _normalize_country_token(m.group(1))
 
-    m = re.match(r'^\s*([A-Za-z]{2,3})\s*[:|]', name)
+    m = re.match(r'^\s*([A-Za-z]{2,3})\s*[:\|\-]', name)
     if m:
         return _normalize_country_token(m.group(1))
 
@@ -168,6 +176,8 @@ class FuzzyMatcher:
         self._callsign_cache.clear()
 
         for name in names:
+            if self._is_group_header(name):
+                continue
             norm = self.normalize_name(name, user_ignored_tags)
             if norm and len(norm) >= 2:
                 norm_lower = norm.lower()
@@ -206,10 +216,22 @@ class FuzzyMatcher:
 
         original_name = name
 
-        # Quality patterns FIRST (before space normalization)
+        # Strip IPTV provider prefixes BEFORE hyphen normalization so that
+        # "FR - CHEVAL TV FHD" loses its "FR - " while the hyphen is still a
+        # hyphen. After hyphen normalization the separator would become a space
+        # and the pattern would fail to match, leaving "FR" as a stray token.
+        for pattern in PROVIDER_PREFIX_PATTERNS:
+            name = re.sub(pattern, '', name, flags=re.IGNORECASE)
+
+        # Quality patterns (before space normalization). Loop until stable so
+        # chained suffixes like "4K HDR" or "UHD HDR" are fully stripped in
+        # successive passes (each pass may expose a token for the next).
         if ignore_quality:
-            for pattern in QUALITY_PATTERNS:
-                name = re.sub(pattern, '', name, flags=re.IGNORECASE)
+            prev = None
+            while prev != name:
+                prev = name
+                for pattern in QUALITY_PATTERNS:
+                    name = re.sub(pattern, '', name, flags=re.IGNORECASE)
 
         # Normalize spacing around numbers
         name = re.sub(r'([a-zA-Z])(\d)', r'\1 \2', name)
@@ -267,10 +289,6 @@ class FuzzyMatcher:
                 break
             name = new_name
 
-        # Remove IPTV provider prefixes (enhanced for Lineuparr)
-        for pattern in PROVIDER_PREFIX_PATTERNS:
-            name = re.sub(pattern, '', name, flags=re.IGNORECASE)
-
         # Build pattern list based on flags
         patterns_to_apply = []
         if ignore_regional:
@@ -308,6 +326,15 @@ class FuzzyMatcher:
         name = re.sub(r'\s+Network\s*$', '', name, flags=re.IGNORECASE)
         name = re.sub(r'\s+Channel\s*$', '', name, flags=re.IGNORECASE)
         name = re.sub(r'\s+TV\s*$', '', name, flags=re.IGNORECASE)
+
+        # Strip decorative Unicode markers (◉, ², superscript letters ᴿᴬᵂ…)
+        # that some IPTV providers append as quality/status badges. Only
+        # characters in decorator categories are removed; accented letters
+        # (é, î, ü…) are in Ll/Lu and are preserved.
+        name = ''.join(
+            ' ' if unicodedata.category(c) in _DECORATOR_CATS else c
+            for c in name
+        )
 
         # Clean up whitespace
         name = re.sub(r'\s+', ' ', name).strip()
@@ -405,18 +432,25 @@ class FuzzyMatcher:
             unique_b = tokens_b - tokens_a
 
             # Subset guard: when one side is a strict subset of the other and
-            # the larger side has a distinctive (>=5 char) token the smaller
-            # lacks, the candidate is a more specific channel than the query
-            # and the high fuzzy score is a false positive. Catches e.g.
-            # "In Country Television" {country, television} vs "Country Music
-            # Television" {country, music, television} — "music" distinguishes
-            # them. Short extras like "live"/"two" do not trigger this guard,
-            # preserving legitimate matches like "ABC News" → "ABC News Live".
+            # the larger side has a distinctive token the smaller lacks, the
+            # candidate is a more specific channel than the query and the high
+            # fuzzy score is a false positive. Catches e.g. "Nickelodeon" vs
+            # "Nickelodeon Teen". Threshold is >=4 chars; "live"/"now" are
+            # explicitly non-distinctive (stream label variants) so "ABC News"
+            # still matches "ABC News Live". Pure-digit tokens >=2 chars
+            # (e.g. "360") are also distinctive: "Canal+Sport" must not match
+            # "Canal+Sport 360".
+            _NON_DISTINCTIVE = frozenset({"live", "now", "new"})
+            def _is_distinctive(t):
+                return t not in _NON_DISTINCTIVE and (
+                    len(t) >= 4 or (t.isdigit() and len(t) >= 2)
+                )
+
             if not unique_a:
-                if any(len(t) >= 5 for t in unique_b):
+                if any(_is_distinctive(t) for t in unique_b):
                     return False
             elif not unique_b:
-                if any(len(t) >= 5 for t in unique_a):
+                if any(_is_distinctive(t) for t in unique_a):
                     return False
 
             # Divergent guard: when BOTH sides have unique tokens AND at least
@@ -469,6 +503,12 @@ class FuzzyMatcher:
                 cleaned_s += ' '
         tokens = sorted([token for token in cleaned_s.split() if token])
         return " ".join(tokens)
+
+    @staticmethod
+    def _is_group_header(name):
+        """Return True for M3U playlist group/section separators like '##### EUROSPORT #####'.
+        These are not real stream names and must be excluded from matching."""
+        return bool(re.search(r'[#=*|]{3,}', name or ""))
 
     @staticmethod
     def _trailing_number(name):
@@ -630,6 +670,8 @@ class FuzzyMatcher:
             return []
 
         for candidate in candidate_names:
+            if self._is_group_header(candidate):
+                continue
             candidate_lower, candidate_nospace = self._get_cached_norm(candidate, user_ignored_tags)
             if not candidate_lower:
                 continue
@@ -660,7 +702,13 @@ class FuzzyMatcher:
                 # like alias "ABC News" vs stream "BBC News" (93%, shares only
                 # "news"; the 3-char call sign "abc"/"bbc" is below the basic
                 # overlap guard's 4-char token floor).
-                if not self._has_token_overlap(best_alias_norm, candidate_lower, require_majority=True):
+                # Use process_string_for_matching (NFD) so accented tokens like
+                # "chérie" match their unaccented stream form "cherie".
+                if not self._has_token_overlap(
+                    self.process_string_for_matching(best_alias_norm),
+                    self.process_string_for_matching(candidate_lower),
+                    require_majority=True,
+                ):
                     continue
 
             if score >= effective_threshold:
@@ -815,15 +863,27 @@ class FuzzyMatcher:
             # channel ("DIRECTV 4K Live 1" vs "... Live 2") -- used to skip
             # those near-identical false positives in the fuzzy stages below.
             query_trailing_num = self._trailing_number(normalized_query_lower)
+            # Detect "+1"/"+2" time-shift suffix so shift channels never match
+            # non-shift streams and vice versa ("Nickelodeon+1" vs "Nickelodeon").
+            # Must check the ORIGINAL name: normalize_name strips "+" (Sm category)
+            # so "+1" becomes "1" post-normalization and would be undetectable.
+            _PLUS_SHIFT_RE = re.compile(r'\+\s{0,2}\d{1,2}\b')
+            query_is_shift = bool(_PLUS_SHIFT_RE.search(lineup_name or ""))
 
             for candidate in candidate_names:
                 if candidate in all_matches:
                     continue  # Already matched via alias
+                if self._is_group_header(candidate):
+                    continue  # Skip M3U group/section separators
 
                 # Use cached normalizations for performance
                 candidate_lower, candidate_nospace = self._get_cached_norm(candidate, user_ignored_tags)
                 if not candidate_lower:
                     continue
+
+                cand_is_shift = bool(_PLUS_SHIFT_RE.search(candidate))
+                if query_is_shift != cand_is_shift:
+                    continue  # Shift channel (+1/+2) must only match shift streams
 
                 if query_trailing_num is not None:
                     cand_trailing_num = self._trailing_number(candidate_lower)
@@ -1002,7 +1062,42 @@ class FuzzyMatcher:
             cand_tokens = set(re.findall(r'[a-z0-9]+', candidate_name.lower()))
             return len(lineup_tokens & cand_tokens)
 
+        # Secondary sort key: prefer streams whose country marker matches the
+        # lineup country (score 1) over streams with an unrecognized prefix like
+        # AF:, TS:, MEO: that pass the hard country filter but should rank below
+        # FR: streams (score 0). Streams with a recognized but wrong country
+        # (already dropped by the filter) would score -1.
+        # Tertiary quality key: prefer HD over 4K/UHD when scores are otherwise
+        # equal — 4K streams are often event-only and less reliable as defaults.
+        _sort_lc = lineup_country.upper() if lineup_country else None
+        _sort_accepted = None
+        if _sort_lc and _sort_lc in _KNOWN_COUNTRY_CODES:
+            _sort_accepted = _COMPATIBLE_COUNTRIES.get(_sort_lc, set()) | {_sort_lc}
+
+        _ULTRA_TIER = re.compile(r'\b(4K|8K|UHD)\b', re.IGNORECASE)
+        _STABLE_TIER = re.compile(r'\b(FHD|HD)\b', re.IGNORECASE)
+
+        def _sort_keys(candidate_name):
+            # Country preference: 1 = matches lineup country, 0 = neutral/unknown, -1 = wrong
+            if _sort_accepted is not None:
+                sc = detect_stream_country(candidate_name)
+                country = 1 if (sc is not None and sc in _sort_accepted) else 0
+            else:
+                country = 0
+            # Quality preference: FHD/HD (1) before 4K/UHD (0) — ultra streams
+            # are often event-only and less reliable as default selections.
+            if _STABLE_TIER.search(candidate_name):
+                quality = 1
+            elif _ULTRA_TIER.search(candidate_name):
+                quality = 0
+            else:
+                quality = 0
+            return country, quality
+
         results = [(name, score, mtype) for name, (score, mtype) in all_matches.items()]
-        results.sort(key=lambda x: (x[1], _orig_overlap(x[0])), reverse=True)
+        results.sort(
+            key=lambda x: (x[1], *_sort_keys(x[0]), _orig_overlap(x[0])),
+            reverse=True,
+        )
         return results
 

--- a/Lineuparr/plugin.py
+++ b/Lineuparr/plugin.py
@@ -67,6 +67,7 @@ class PluginConfig:
 
     DEFAULT_FUZZY_MATCH_THRESHOLD = 80
     DEFAULT_PRIORITIZE_QUALITY = True
+    DEFAULT_BLOCK_QUALITY_STREAMS = False
     DEFAULT_RATE_LIMITING = "none"
     DEFAULT_CHANNEL_NUMBERING = "lineup"
 
@@ -442,6 +443,18 @@ class Plugin:
                 "type": "boolean",
                 "default": True,
                 "help_text": "Sort attached streams by quality (4K > UHD > FHD > HD > SD). Uses probed resolution if available.",
+            },
+            {
+                "id": "block_quality_streams_on_sd_channels",
+                "label": "Block Quality Streams on Standard Channels",
+                "type": "boolean",
+                "default": False,
+                "help_text": (
+                    "When on, streams with 4K/8K/UHD/HDR tags in their name are excluded "
+                    "from matching lineup channels that have no quality suffix (e.g. TF1, M6). "
+                    "Quality-declared lineup channels (e.g. France 2 UHD) always require a "
+                    "matching quality stream, regardless of this setting."
+                ),
             },
             {
                 "id": "preserve_existing_streams",
@@ -1474,6 +1487,7 @@ class Plugin:
         try:
             numbering_mode = self._resolve_numbering_mode(settings)
             use_number_boost = (numbering_mode == "lineup")
+            block_quality = settings.get("block_quality_streams_on_sd_channels", PluginConfig.DEFAULT_BLOCK_QUALITY_STREAMS)
             lineup = self._load_filtered_lineup(settings, logger)
             if lineup.get("status") == "error":
                 return lineup
@@ -1526,6 +1540,7 @@ class Plugin:
                         ch_name, unique_stream_names, alias_map,
                         channel_number=boost_number,
                         lineup_country=lineup_cc,
+                        block_quality_streams=block_quality,
                     )
 
                     if matches:
@@ -2135,6 +2150,7 @@ class Plugin:
         use_number_boost = (self._resolve_numbering_mode(settings) == "lineup")
         prioritize_quality = settings.get("prioritize_quality", PluginConfig.DEFAULT_PRIORITIZE_QUALITY)
         preserve = settings.get("preserve_existing_streams", False)
+        block_quality = settings.get("block_quality_streams_on_sd_channels", PluginConfig.DEFAULT_BLOCK_QUALITY_STREAMS)
 
         if not self._acquire_lock(logger):
             return {"status": "error", "message": "Another operation is in progress. Try again later."}
@@ -2214,6 +2230,7 @@ class Plugin:
                         ch_name, unique_stream_names, alias_map,
                         channel_number=ch_number,
                         lineup_country=lineup_cc,
+                        block_quality_streams=block_quality,
                     )
 
                     if matches:


### PR DESCRIPTION
## Summary

- Adds `_has_upgrade_quality()` helper in `fuzzy_matcher.py` — detects upgrade quality markers (`4K`, `8K`, `UHD`, `HDR`, `ᵁᴴᴰ`) in raw stream/lineup names
- Lineup channels declared with a quality suffix (e.g. `France 2 UHD`) now **only match streams that also carry an upgrade marker** — unconditional, always active
- New plugin setting **"Block Quality Streams on Standard Channels"** (default: OFF) — when enabled, streams with `4K/8K/UHD/HDR` are excluded from matching standard channels like `TF1` or `M6`
- `HD`, `FHD`, `HEVC` are unaffected — treated as standard quality as before

## Test Plan

- [ ] With option OFF: verify `FR: TF1 4K` still matches `TF1` (existing behaviour)
- [ ] With option ON: verify `FR: TF1 4K` and `FR - TF1 4K HDR` no longer match `TF1`
- [ ] With option ON: verify `FR: TF1 HD` still matches `TF1`
- [ ] Verify `France 2 UHD` (lineup) only matches streams with 4K/UHD in their name, regardless of option
- [ ] Verify `FR: FRANCE 2` does not match `France 2 UHD` (lineup)

🤖 Generated with [Claude Code](https://claude.com/claude-code)