### PR TITLE
Quality aware matching

### DIFF
--- a/Lineuparr/fuzzy_matcher.py
+++ b/Lineuparr/fuzzy_matcher.py
@@ -805,11 +805,11 @@ class FuzzyMatcher:
         # Quality-aware pre-filtering (opt-in via quality_aware).
         # Both tiers are gated: upgrade channels only match upgrade streams,
         # standard channels only match standard streams. Streams listed in
-        # alias_map for a standard channel bypass the filter.
+        # alias_map for either tier bypass the filter.
         if quality_aware:
             lineup_is_upgrade = has_upgrade_quality(lineup_name or "")
             explicit_bypass = set()
-            if not lineup_is_upgrade and alias_map:
+            if alias_map:
                 raw = alias_map.get(lineup_name, [])
                 alias_list = [raw] if isinstance(raw, str) else list(raw)
                 norm_aliases = {

--- a/Lineuparr/fuzzy_matcher.py
+++ b/Lineuparr/fuzzy_matcher.py
@@ -29,6 +29,16 @@ QUALITY_PATTERNS = [
     r'\s+\b(4K|8K|UHD|FHD|HD|SD|FD|Unknown|Unk|Slow|Dead)\b\s+',
 ]
 
+# Quality markers that distinguish an upgrade-tier channel from its standard twin.
+# HD/FHD/HEVC are intentionally excluded — they don't create a separate twin channel.
+_UPGRADE_QUALITY_RE = re.compile(r'\b(?:4K|8K|UHD|HDR)\b|ᵁᴴᴰ', re.IGNORECASE)
+
+
+def has_upgrade_quality(name: str) -> bool:
+    """Return True if name contains an upgrade quality marker (4K/8K/UHD/HDR)."""
+    return bool(_UPGRADE_QUALITY_RE.search(name))
+
+
 REGIONAL_PATTERNS = [
     # East/West are intentionally NOT stripped — they distinguish separate channel feeds
     # (e.g., "HBO East" and "HBO West" are different channels)
@@ -768,7 +778,7 @@ class FuzzyMatcher:
         return None, 0, None
 
     def match_all_streams(self, lineup_name, candidate_names, alias_map, channel_number=None,
-                          user_ignored_tags=None, lineup_country=None):
+                          user_ignored_tags=None, lineup_country=None, quality_aware=False):
         """
         Full matching pipeline for Lineuparr: alias → exact → substring → fuzzy, with number boost.
         Returns ALL matching streams sorted by score.
@@ -779,6 +789,9 @@ class FuzzyMatcher:
             alias_map: Alias dict
             channel_number: Expected channel number for boost
             user_ignored_tags: Tags to strip
+            quality_aware: When True, upgrade streams (4K/8K/UHD/HDR) are excluded
+                from standard channels. Streams listed in alias_map for this channel bypass
+                the filter (e.g. "France 2": ["FRANCE 2 4K HDR"] allows that specific stream).
 
         Returns:
             List of (stream_name, score, match_type) tuples sorted by score desc.
@@ -788,6 +801,32 @@ class FuzzyMatcher:
 
         if user_ignored_tags is None:
             user_ignored_tags = []
+
+        # Quality-aware pre-filtering (opt-in via quality_aware).
+        # Both tiers are gated: upgrade channels only match upgrade streams,
+        # standard channels only match standard streams. Streams listed in
+        # alias_map for a standard channel bypass the filter.
+        if quality_aware:
+            lineup_is_upgrade = has_upgrade_quality(lineup_name or "")
+            explicit_bypass = set()
+            if not lineup_is_upgrade and alias_map:
+                raw = alias_map.get(lineup_name, [])
+                alias_list = [raw] if isinstance(raw, str) else list(raw)
+                norm_aliases = {
+                    self.normalize_name(a, ignore_quality=False).lower()
+                    for a in alias_list
+                    if self.normalize_name(a, ignore_quality=False)
+                }
+                for c in candidate_names:
+                    norm_c = self.normalize_name(c, ignore_quality=False)
+                    if norm_c and norm_c.lower() in norm_aliases:
+                        explicit_bypass.add(c)
+            candidate_names = [
+                c for c in candidate_names
+                if has_upgrade_quality(c) == lineup_is_upgrade or c in explicit_bypass
+            ]
+            if not candidate_names:
+                return []
 
         # Callsign anchor (asymmetric): extract the lineup channel's US
         # broadcast callsign up front. Used after the fuzzy stages to floor

--- a/Lineuparr/plugin.py
+++ b/Lineuparr/plugin.py
@@ -450,9 +450,10 @@ class Plugin:
                 "type": "boolean",
                 "default": False,
                 "help_text": (
-                    "When on, channels that have a UHD/4K twin in the lineup are automatically "
-                    "restricted to standard streams (e.g. TF1 only matches TF1/TF1 FHD, not TF1 4K). "
-                    "The twin channel (e.g. TF1 UHD) receives the upgrade streams exclusively. "
+                    "When on, if the lineup contains both TF1 and TF1 UHD, each is restricted "
+                    "to streams of its own quality tier: TF1 only matches standard streams, "
+                    "TF1 UHD only matches upgrade streams (4K/8K/UHD/HDR). "
+                    "Channels with no twin in the lineup are unaffected. "
                     "Streams listed in a channel's aliases bypass this filter."
                 ),
             },
@@ -921,7 +922,8 @@ class Plugin:
             return set()
         twin_set = self._build_upgrade_twin_set(lineup, matcher)
         if logger and twin_set:
-            logger.info(f"{LOG_PREFIX} Quality-aware matching active for: {sorted(twin_set)}")
+            logger.info(f"{LOG_PREFIX} Quality-aware matching active for {len(twin_set)} channel(s)")
+            logger.debug(f"{LOG_PREFIX} Quality-aware twins: {sorted(twin_set)}")
         return twin_set
 
     def _get_filtered_epg_data(self, settings, logger):

--- a/Lineuparr/plugin.py
+++ b/Lineuparr/plugin.py
@@ -17,7 +17,7 @@ from glob import glob
 
 from django.db import transaction
 
-from .fuzzy_matcher import FuzzyMatcher
+from .fuzzy_matcher import FuzzyMatcher, has_upgrade_quality
 from .aliases import CHANNEL_ALIASES
 from .progress_status import save_progress_atomic, load_progress, build_status_message
 
@@ -67,6 +67,7 @@ class PluginConfig:
 
     DEFAULT_FUZZY_MATCH_THRESHOLD = 80
     DEFAULT_PRIORITIZE_QUALITY = True
+    DEFAULT_QUALITY_AWARE_STREAM_MATCHING = False
     DEFAULT_RATE_LIMITING = "none"
     DEFAULT_CHANNEL_NUMBERING = "lineup"
 
@@ -442,6 +443,18 @@ class Plugin:
                 "type": "boolean",
                 "default": True,
                 "help_text": "Sort attached streams by quality (4K > UHD > FHD > HD > SD). Uses probed resolution if available.",
+            },
+            {
+                "id": "quality_aware_stream_matching",
+                "label": "Quality-Aware Stream Matching",
+                "type": "boolean",
+                "default": False,
+                "help_text": (
+                    "When on, channels that have a UHD/4K twin in the lineup are automatically "
+                    "restricted to standard streams (e.g. TF1 only matches TF1/TF1 FHD, not TF1 4K). "
+                    "The twin channel (e.g. TF1 UHD) receives the upgrade streams exclusively. "
+                    "Streams listed in a channel's aliases bypass this filter."
+                ),
             },
             {
                 "id": "preserve_existing_streams",
@@ -874,6 +887,42 @@ class Plugin:
                 )
 
         return alias_map
+
+    def _build_upgrade_twin_set(self, lineup, matcher):
+        """Return lineup channel names (both tiers) that have a twin in the other tier.
+
+        Example: if the lineup contains both "France 2" and "France 2 UHD", both
+        are returned. The matcher then restricts each to streams of its own quality
+        tier (standard streams for "France 2", upgrade streams for "France 2 UHD").
+        """
+        all_names = [ch["name"] for cat in lineup["categories"].values() for ch in cat]
+        upgrade_bases = set()
+        standard_bases = set()
+        for name in all_names:
+            base = matcher.normalize_name(name, ignore_quality=True)
+            if base:
+                if has_upgrade_quality(name):
+                    upgrade_bases.add(base.lower())
+                else:
+                    standard_bases.add(base.lower())
+        twin_set = set()
+        for name in all_names:
+            base = matcher.normalize_name(name, ignore_quality=True)
+            if base:
+                if has_upgrade_quality(name) and base.lower() in standard_bases:
+                    twin_set.add(name)
+                elif not has_upgrade_quality(name) and base.lower() in upgrade_bases:
+                    twin_set.add(name)
+        return twin_set
+
+    def _get_upgrade_twin_set(self, settings, lineup, matcher, logger=None):
+        """Return the upgrade twin set if quality_aware_stream_matching is enabled, else empty set."""
+        if not settings.get("quality_aware_stream_matching", PluginConfig.DEFAULT_QUALITY_AWARE_STREAM_MATCHING):
+            return set()
+        twin_set = self._build_upgrade_twin_set(lineup, matcher)
+        if logger and twin_set:
+            logger.info(f"{LOG_PREFIX} Quality-aware matching active for: {sorted(twin_set)}")
+        return twin_set
 
     def _get_filtered_epg_data(self, settings, logger):
         """Fetch EPG data, optionally filtered and prioritized by selected sources."""
@@ -1479,6 +1528,7 @@ class Plugin:
                 return lineup
             matcher = self._init_fuzzy_matcher(settings, logger)
             alias_map = self._build_alias_map(settings, logger)
+            upgrade_twin_set = self._get_upgrade_twin_set(settings, lineup, matcher)
             streams = self._get_all_streams(settings, logger)
             assigner = self._init_assigner_state(settings)
             lineup_cc, _ = self._parse_lineup_filename(settings.get("lineup_file", ""))
@@ -1526,6 +1576,7 @@ class Plugin:
                         ch_name, unique_stream_names, alias_map,
                         channel_number=boost_number,
                         lineup_country=lineup_cc,
+                        quality_aware=(ch_name in upgrade_twin_set),
                     )
 
                     if matches:
@@ -2169,6 +2220,8 @@ class Plugin:
             matcher.precompute_normalizations(unique_stream_names)
             matcher.country_filter_drops = 0
 
+            upgrade_twin_set = self._get_upgrade_twin_set(settings, lineup, matcher, logger)
+
             # Get existing groups and channels
             existing_groups = {g['name']: g['id'] for g in ChannelGroup.objects.all().values('id', 'name')}
             existing_channels = {}
@@ -2214,6 +2267,7 @@ class Plugin:
                         ch_name, unique_stream_names, alias_map,
                         channel_number=ch_number,
                         lineup_country=lineup_cc,
+                        quality_aware=(ch_name in upgrade_twin_set),
                     )
 
                     if matches:

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,24 @@
+"""
+Mock out Dispatcharr/Django dependencies so fuzzy_matcher tests can run
+without a full Dispatcharr installation.
+"""
+import sys
+from unittest.mock import MagicMock
+
+_MOCKED = [
+    "django",
+    "django.db",
+    "django.db.transaction",
+    "apps",
+    "apps.channels",
+    "apps.channels.models",
+    "apps.m3u",
+    "apps.m3u.models",
+    "apps.epg",
+    "apps.epg.models",
+    "core",
+    "core.utils",
+]
+
+for _mod in _MOCKED:
+    sys.modules.setdefault(_mod, MagicMock())


### PR DESCRIPTION
## What

Adds a **Quality-Aware Stream Matching** toggle (off by default).

When enabled, the matcher detects lineup channels that exist in two quality tiers (e.g. *France 2* + *France 2 UHD*) and restricts each to streams of its own tier:

- Standard channels (France 2) → only match standard streams
- Upgrade channels (France 2 UHD) → only match upgrade streams (4K/8K/UHD/HDR)

Channels **without** a twin in the lineup are unaffected — they match all streams as before.

Streams listed in a channel's aliases bypass the filter (e.g. an alias `"France 2": ["FRANCE 2 4K HDR"]` allows that specific upgrade stream through for the standard channel).