### PR TITLE
fix(core): re-vendor bug-098 callsign-rescue hardening

### DIFF
--- a/.github/scripts/core_manifest.json
+++ b/.github/scripts/core_manifest.json
@@ -1,3 +1,3 @@
 {
-  "matching_core.py": "2ac7ac4cb283306152701bfd977ff2f13700d63d8023fdfa280b1480f5a969dc"
+  "matching_core.py": "d9a2d065584fb797789f3afe3d51dbd94d3d28a1666361b1f22c8eec6b03943b"
 }

--- a/Lineuparr/matching_core.py
+++ b/Lineuparr/matching_core.py
@@ -702,9 +702,21 @@ class FuzzyMatcherCore:
         'KIND', 'KING', 'KINGS', 'KISS', 'KITE', 'KNEE', 'KNEW', 'KNOW', 'KNOWN',
     })
 
+    # OTA branding context that immediately follows a station callsign: a channel
+    # number (optionally prefixed by a broadcast suffix), e.g. "KING 5", "WAVE 3",
+    # "WOOD TV8", "WHO 13". Used to rescue a denylisted common-word callsign in a
+    # loose position WITHOUT also rescuing bare program words ("King of the Hill",
+    # "Doctor Who"), which never carry this trailing number. bug-098.
+    _OTA_NUMBER_CONTEXT = re.compile(r'^\s+(?:TV|DT|CD|LP|LD)?\s*\d{1,3}\b', re.IGNORECASE)
+
     def _is_callsign_allowed(self, callsign):
         """A candidate callsign is allowed if it is not denylisted, OR the plugin
-        supplied a known-real callsign set that contains it (DB rescue)."""
+        supplied a known-real callsign set that contains it (DB rescue).
+
+        NOTE: this full rescue is used only at the PARENTHESIZED priorities (1/1b),
+        where the parentheses are an unambiguous OTA signal. The end-of-name and
+        loose priorities deliberately do NOT use it for denylisted words -- see
+        bug-098 hardening in _compute_callsign_with_confidence."""
         return (callsign not in self._CALLSIGN_DENYLIST
                 or (self._known_callsigns is not None and callsign in self._known_callsigns))
 
@@ -746,18 +758,28 @@ class FuzzyMatcherCore:
         if paren_suffix_match:
             return paren_suffix_match.group(1).upper(), True
 
-        # Priority 3: Callsigns at the end
+        # Priority 3: Callsigns at the end. A denylisted common word at the end
+        # ("WOLF KING", "Doctor Who") is NOT rescued here -- end position alone is
+        # too weak a signal for a word that is also a real callsign. Non-denylisted
+        # callsigns (and suffixed forms like "KING-TV") still match. bug-098.
         end_match = re.search(r'\b([KW][A-Z]{2,4}(?:-(?:TV|CD|LP|DT|LD))?)\s*(?:\.[a-z]+)?\s*$', channel_name, re.IGNORECASE)
         if end_match:
             callsign = end_match.group(1).upper()
-            if self._is_callsign_allowed(callsign):
+            if callsign not in self._CALLSIGN_DENYLIST:
                 return callsign, True
 
-        # Priority 4: Any word matching callsign pattern (low confidence)
+        # Priority 4: Any word matching callsign pattern (low confidence). A
+        # denylisted common word is rescued here ONLY in OTA branding context --
+        # immediately followed by a channel number ("KING 5", "WAVE 3", "WOOD
+        # TV8", "WHO 13") -- never as a bare program word ("King of the Hill",
+        # "Doctor Who", "Will Ferrell"). bug-098.
         word_match = re.search(r'\b([KW][A-Z]{2,4}(?:-(?:TV|CD|LP|DT|LD))?)\b', channel_name, re.IGNORECASE)
         if word_match:
             callsign = word_match.group(1).upper()
-            if self._is_callsign_allowed(callsign):
+            if callsign not in self._CALLSIGN_DENYLIST:
+                return callsign, False
+            if (self._known_callsigns is not None and callsign in self._known_callsigns
+                    and self._OTA_NUMBER_CONTEXT.match(channel_name[word_match.end():])):
                 return callsign, False
 
         return None, False

--- a/Lineuparr/plugin.json
+++ b/Lineuparr/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "Lineuparr",
-  "version": "1.26.1791747",
+  "version": "1.26.1802331",
   "description": "Mirror real-world provider channel lineups by creating channel groups, channels, and fuzzy-matching IPTV streams to them.",
   "author": "PiratesIRC",
   "license": "MIT",

--- a/Lineuparr/plugin.py
+++ b/Lineuparr/plugin.py
@@ -64,7 +64,7 @@ def _clean_json_text(s):
 
 
 class PluginConfig:
-    PLUGIN_VERSION = "1.26.1791747"
+    PLUGIN_VERSION = "1.26.1802331"
 
     DEFAULT_FUZZY_MATCH_THRESHOLD = 80
     DEFAULT_PRIORITIZE_QUALITY = True


### PR DESCRIPTION
Vendor-sync of the shared matcher core (`matching_core.py`) with the bug-098 hardening landed in the workspace source.

## What changed in the core
`FuzzyMatcherCore._compute_callsign_with_confidence` now gates the DB-rescue of a denylisted common-word callsign (KING/WHO/WOLF/WAVE/WOOD/WEEK...):
- No rescue at end-of-name (kills "WOLF KING", "Doctor Who").
- Loose path rescues only in OTA branding context, i.e. immediately followed by a channel number (preserves "KING 5", "WAVE 3", "WOOD TV8", "WHO 13"; rejects "King of the Hill").
- Parenthesized positions keep the full rescue.

## Impact on Lineuparr: none (behavior-identical)
Lineuparr never populates `known_callsigns` (no channel DB), so the rescue path was already inert and the denylist stays fully active regardless. This sync keeps the vendored core byte-identical to the workspace source (parity gate) and is pure future-proofing.

Golden baseline unchanged. Parity gate green. 430 tests green.

No release / Hub submission yet.

Generated with [Claude Code](https://claude.com/claude-code)