### PR TITLE
Embedded lineup aliases and alias-anchored callsign matching

### DIFF
--- a/Lineuparr/fuzzy_matcher.py
+++ b/Lineuparr/fuzzy_matcher.py
@@ -307,6 +307,11 @@ class FuzzyMatcher(FuzzyMatcherCore):
         # match_all_streams calls. Callers reset this before a matching loop
         # and read it after, so they can log a summary.
         self.country_filter_drops = 0
+        # Compiled whole-token matchers keyed by callsign, built on demand by
+        # the alias-anchored callsign rescue. The same handful of callsigns is
+        # re-tested against every stream for every lineup channel, so compiling
+        # once per callsign matters.
+        self._alias_callsign_patterns = {}
 
     def precompute_normalizations(self, names, user_ignored_tags=None):
         """
@@ -466,9 +471,99 @@ class FuzzyMatcher(FuzzyMatcherCore):
             if score >= effective_threshold:
                 matches.append((candidate, score, "alias"))
 
+        # Stage 0b: alias-anchored callsign rescue.
+        matches.extend(
+            self._alias_callsign_matches(aliases, candidate_names,
+                                         already_matched={m[0] for m in matches})
+        )
+
         # Sort by score descending
         matches.sort(key=lambda x: x[1], reverse=True)
         return matches
+
+    # A US broadcast callsign is K/W plus 2-4 letters, optionally carrying a
+    # broadcast suffix. The suffix may be hyphenated (WWOR-TV) or run together
+    # (WWORDT), and lineup data uses both.
+    _CALLSIGN_SHAPE = re.compile(r'^[KW][A-Z]{2,4}$')
+    _CALLSIGN_SUFFIX = re.compile(r'(TV|DT|CD|LP|LD)$')
+
+    def _alias_callsign(self, alias):
+        """Return the bare callsign an alias declares, or None.
+
+        Only an alias that is ENTIRELY a callsign counts. A phrase that merely
+        contains a K/W word ("MY NETWORK TV NEW YORK") is not a declaration that
+        the channel has that callsign, and treating it as one would anchor on an
+        ordinary word.
+
+        The core callsign denylist is applied, so common English words with
+        callsign shape (KIDS, WORLD, WOMEN, WEST, KISS, WWE) never anchor. That
+        denylist exists because regex alone cannot tell "WITH" from "WABC".
+        """
+        compact = re.sub(r'[^A-Za-z0-9]', '', alias or "").upper()
+        if not compact:
+            return None
+
+        stem = compact
+        if not self._CALLSIGN_SHAPE.match(stem):
+            # Try again without a run-together broadcast suffix (WWORDT -> WWOR).
+            stripped = self._CALLSIGN_SUFFIX.sub('', compact)
+            if stripped == compact:
+                return None
+            stem = stripped
+
+        if not self._CALLSIGN_SHAPE.match(stem):
+            return None
+        if stem in self._CALLSIGN_DENYLIST:
+            return None
+        return stem
+
+    def _alias_callsign_pattern(self, callsign):
+        """Compiled whole-token matcher for a callsign inside a stream name.
+
+        Matched against the ORIGINAL stream name, not the normalized form:
+        normalize_name strips parenthesized text, which would discard the single
+        most reliable callsign form there is ("... SECAUCUS NY (WWOR)").
+        """
+        pattern = self._alias_callsign_patterns.get(callsign)
+        if pattern is None:
+            # A run-together suffix is accepted only for TV and DT, the two forms
+            # lineup data actually uses (WWORTV, WWORDT). Accepting LD run-together
+            # would make callsign WWOR match the word WWORLD, since the regex would
+            # read the trailing "LD" as a broadcast suffix.
+            pattern = re.compile(
+                r'(?<![A-Za-z0-9])' + re.escape(callsign)
+                + r'(?:[-\s](?:TV|DT|CD|LP|LD)|TV|DT)?(?![A-Za-z0-9])',
+                re.IGNORECASE,
+            )
+            self._alias_callsign_patterns[callsign] = pattern
+        return pattern
+
+    def _alias_callsign_matches(self, aliases, candidate_names, already_matched):
+        """Match streams that carry a callsign this channel's aliases declare.
+
+        The core callsign anchor in match_all_streams only fires when the LINEUP
+        channel name carries a callsign, so a lineup entry named "My9 New York"
+        could never reach a stream named "US: MY 9 WWOR NEW YORK". An alias of
+        "WWOR" states the callsign explicitly, which is the missing half.
+
+        Scored at 95 to sit level with the core callsign anchor and below an
+        exact alias match, and returned with its own match type so a report can
+        tell the two apart. These matches stay subject to the country and region
+        filters in match_all_streams.
+        """
+        callsigns = {cs for cs in (self._alias_callsign(a) for a in aliases) if cs}
+        if not callsigns:
+            return []
+
+        rescued = []
+        for candidate in candidate_names:
+            if candidate in already_matched or self._is_group_header(candidate):
+                continue
+            for callsign in callsigns:
+                if self._alias_callsign_pattern(callsign).search(candidate):
+                    rescued.append((candidate, 95, "alias-callsign"))
+                    break
+        return rescued
 
     def fuzzy_match(self, query_name, candidate_names, user_ignored_tags=None,
                     ignore_quality=True, ignore_regional=True, ignore_geographic=True, ignore_misc=True):

--- a/Lineuparr/plugin.py
+++ b/Lineuparr/plugin.py
@@ -907,6 +907,8 @@ class Plugin:
             for k, v in COUNTRY_ALIASES.get(lineup_cc.upper(), {}).items():
                 alias_map[k] = list(dict.fromkeys(alias_map.get(k, []) + list(v)))
 
+        self._merge_embedded_aliases(alias_map, settings, logger)
+
         custom_str = _clean_json_text(settings.get("custom_aliases") or "")
         if custom_str:
             try:
@@ -957,6 +959,76 @@ class Plugin:
                 )
 
         return alias_map
+
+    def _merge_embedded_aliases(self, alias_map, settings, logger):
+        """Merge per-channel "aliases" arrays carried inside the lineup JSON.
+
+        A lineup channel entry may declare its own aliases:
+
+            {"name": "My9 New York", "number": 509,
+             "aliases": ["WWOR", "WWOR-TV", "MY9"]}
+
+        This lets a lineup ship the stream-name variants that are specific to it
+        (provider callsigns, HDHomeRun and XMLTV display names) without adding
+        them to the global built-in table, where a name that exists in several
+        markets would leak across countries.
+
+        Merged after the built-in and country-scoped tables and before the user's
+        custom aliases, so the user setting still has the last word. A lineup
+        that cannot be read leaves the alias map untouched: aliases are an
+        enhancement, and failing the whole matching run over them would trade a
+        missing alias for no matches at all.
+        """
+        try:
+            lineup = self._load_lineup(settings, logger)
+        except Exception as e:
+            logger.warning(f"{LOG_PREFIX} Could not read embedded lineup aliases: {e}")
+            return
+
+        categories = lineup.get("categories") if isinstance(lineup, dict) else None
+        if not isinstance(categories, dict):
+            return
+
+        merged = 0
+        for channels in categories.values():
+            if not isinstance(channels, list):
+                continue
+            for channel in channels:
+                if not isinstance(channel, dict):
+                    continue
+
+                name = str(channel.get("name") or "").strip()
+                raw = channel.get("aliases")
+                if not name or not raw:
+                    continue
+
+                # Same shapes the custom_aliases setting accepts: a list, or a
+                # bare string for a single alias. Anything else is a mistake in
+                # the lineup file and is reported rather than dropped silently.
+                if isinstance(raw, str):
+                    candidates = [raw]
+                elif isinstance(raw, list):
+                    candidates = raw
+                else:
+                    logger.warning(
+                        f"{LOG_PREFIX} Lineup aliases for '{name}' must be a string "
+                        f"or list, got {type(raw).__name__} - ignored"
+                    )
+                    continue
+
+                clean = [a.strip() for a in candidates
+                         if isinstance(a, str) and a.strip()]
+                if not clean:
+                    continue
+
+                alias_map[name] = list(dict.fromkeys(alias_map.get(name, []) + clean))
+                merged += 1
+
+        if merged:
+            logger.info(
+                f"{LOG_PREFIX} Merged embedded aliases from {merged} lineup "
+                f"{'channel' if merged == 1 else 'channels'}"
+            )
 
     def _build_upgrade_twin_set(self, lineup, matcher):
         """Return lineup channel names (both tiers) that have a twin in the other tier.


### PR DESCRIPTION
Implements the two behaviours requested in #18, against the existing matcher rather than as a `plugin.py` / `plugin_base.py` split.

## What this adds

**Embedded lineup aliases.** A lineup JSON channel entry may carry its own `aliases` array:

```json
{"name": "My9 New York", "number": 509, "aliases": ["WWOR", "WWOR-TV", "MY9"]}
```

`Plugin._merge_embedded_aliases` in `Lineuparr/plugin.py` merges those into the alias map after the built-in and country-scoped tables and before the user's Custom Channel Aliases setting, so that setting still has the last word. A lineup that cannot be read logs a warning and leaves the alias map unchanged. Lineups without an `aliases` key behave exactly as before.

**Alias-anchored callsign matching.** When one of a channel's aliases IS a US broadcast callsign, a stream carrying that callsign as a whole token now matches, scored 95 with match type `alias-callsign`. The existing callsign anchor only fires when the LINEUP name carries a callsign, so a lineup entry named "My9 New York" could not reach a stream named "US: MY 9 WWOR NEW YORK".

## Three details that matter

- The callsign denylist already in `matching_core.py` is reused, so common K/W words with callsign shape (KIDS, WORLD, WOMEN, WEST, KISS, WWE) never anchor.
- The token test runs on the ORIGINAL stream name. `normalize_name` strips parenthesized text, which would otherwise discard the most reliable callsign form there is, `... SECAUCUS NY (WWOR)`.
- Only an alias that is entirely a callsign counts. A display name such as "WGN America" is not a declaration that the channel owns every stream carrying WGN.

Run-together broadcast suffixes are limited to TV and DT. Accepting LD without a separator made callsign WWOR match the word WWORLD.

Country and region filtering still apply to these matches.

## Verification

- 59 new tests; local suite at 489 passing, up from 430.
- Static plugin validation, vendored-core parity and matcher golden drift gates all pass.
- `ruff check` reports the same 17 pre-existing findings on these two files as on `main`; none added.
- All four example stream names from #18 match, including the parenthesized `US| MY 9 SECAUCUS NY (WWOR)` form.
- Mutation testing: four deliberate breakages of the new guards were each caught by the tests, with a no-op control correctly not caught.
- Cost measured at 0.40 s for 27 lineup channels against 5,000 streams.

The lineup data file from #18 is deliberately not included here and should land separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QVyYBWwJS3HAv18aT8xyNN
