### PR TITLE
Per-channel country in a lineup, and country-scoped alias maps

### DIFF
--- a/Lineuparr/fuzzy_matcher.py
+++ b/Lineuparr/fuzzy_matcher.py
@@ -227,6 +227,41 @@ def detect_stream_country(name):
     return None
 
 
+def detect_name_country_prefix(channel_name):
+    """Split a "CC_" country prefix off a lineup channel name.
+
+    A lineup channel may declare its own country by name: "UK_CNN" inside a US
+    lineup means match this channel against UK streams. Returns
+    (country_code, stripped_name), or (None, channel_name) unchanged when there
+    is no recognized prefix.
+
+    Only the curated _KNOWN_COUNTRY_CODES are accepted, so an ordinary name that
+    happens to contain an underscore ("MTV_Live", "My_Channel") is left alone.
+    The two letters must be followed by an underscore and by something other
+    than whitespace, so a name ending at the prefix is not turned into an empty
+    channel name.
+
+    This lives beside detect_category_country because both answer the same
+    question from a different string, and both need the country vocabulary that
+    is private to this module.
+    """
+    if not channel_name:
+        return None, channel_name
+
+    m = re.match(r'^([A-Za-z]{2})_(.+)$', channel_name)
+    if not m:
+        return None, channel_name
+
+    code = m.group(1).upper()
+    if code not in _KNOWN_COUNTRY_CODES:
+        return None, channel_name
+
+    stripped = m.group(2).strip()
+    if not stripped:
+        return None, channel_name
+    return code, stripped
+
+
 def detect_category_country(category_name):
     """Detect an ISO-2 country code from a lineup category-name prefix.
 

--- a/Lineuparr/plugin.py
+++ b/Lineuparr/plugin.py
@@ -18,7 +18,8 @@ from glob import glob
 
 from django.db import transaction
 
-from .fuzzy_matcher import FuzzyMatcher, has_upgrade_quality, detect_category_country, country_codes_in_text
+from .fuzzy_matcher import (FuzzyMatcher, has_upgrade_quality, detect_category_country,
+                            detect_name_country_prefix, country_codes_in_text)
 from .aliases import CHANNEL_ALIASES, COUNTRY_ALIASES
 from .progress_status import save_progress_atomic, load_progress, build_status_message
 
@@ -620,6 +621,8 @@ class Plugin:
         if "categories" not in data:
             raise ValueError(f"Invalid lineup file: missing 'categories' key")
 
+        self._rewrite_country_prefixes(data, logger)
+
         # Apply category detail level transformation
         data = self._apply_category_detail(data, detail)
 
@@ -627,6 +630,60 @@ class Plugin:
         self._lineup_cache_file = cache_key
         logger.info(f"{LOG_PREFIX} Loaded lineup: {data.get('package', 'Unknown')} ({sum(len(v) for v in data['categories'].values())} channels, {len(data['categories'])} categories, detail={detail})")
         return data
+
+    @staticmethod
+    def _rewrite_country_prefixes(data, logger):
+        """Turn a "CC_" channel-name prefix into the channel's own country.
+
+        "UK_CNN" inside a US lineup becomes name "CNN" with country UK. Done here,
+        once, before anything else sees the lineup: the name is used for channel
+        creation, for matching, for reports and for EPG matching, so a prefix left
+        in place would have to be stripped correctly in several unrelated places.
+
+        Mutates data in place. Runs before _apply_category_detail so every detail
+        level sees the rewritten entries.
+        """
+        rewritten = 0
+        for channels in data.get("categories", {}).values():
+            if not isinstance(channels, list):
+                continue
+            for entry in channels:
+                if not isinstance(entry, dict):
+                    continue
+                country, stripped = detect_name_country_prefix(entry.get("name"))
+                if not country:
+                    continue
+                entry["name"] = stripped
+                entry["_country"] = country
+                rewritten += 1
+
+        if rewritten:
+            logger.info(
+                f"{LOG_PREFIX} {rewritten} lineup "
+                f"{'channel carries' if rewritten == 1 else 'channels carry'} a "
+                f"country prefix in the name"
+            )
+
+    @staticmethod
+    def _resolve_entry_country(entry, category_cc, logger=None):
+        """Country code to enforce for ONE channel.
+
+        Most specific first: the channel's own country (from its name prefix),
+        then the category's, then the lineup filename's, which category_cc already
+        carries. Mirrors _resolve_category_country one level down.
+
+        The override is logged for the same reason the category-level one is: a
+        channel that does not match is otherwise guesswork.
+        """
+        entry_cc = entry.get("_country") if isinstance(entry, dict) else None
+        if not entry_cc:
+            return category_cc
+        if logger is not None and entry_cc != category_cc:
+            logger.info(
+                f"{LOG_PREFIX} Channel '{entry.get('name')}' country: {entry_cc} "
+                f"(from name prefix, overriding {category_cc or 'lineup default'})"
+            )
+        return entry_cc
 
     def _apply_category_detail(self, data, detail):
         """Transform lineup categories based on the detail level setting.
@@ -1788,13 +1845,14 @@ class Plugin:
                         return
 
                     ch_name = entry["name"]
+                    entry_cc = self._resolve_entry_country(entry, cat_cc, logger)
                     ch_number = self._get_channel_number(settings, entry, assigner)
                     boost_number = self._parse_channel_number(entry.get("number")) if use_number_boost else None
 
                     matches = matcher.match_all_streams(
-                        ch_name, unique_stream_names, alias_map_for(cat_cc),
+                        ch_name, unique_stream_names, alias_map_for(entry_cc),
                         channel_number=boost_number,
-                        lineup_country=cat_cc,
+                        lineup_country=entry_cc,
                         quality_aware=(ch_name in upgrade_twin_set),
                     )
 
@@ -2474,6 +2532,7 @@ class Plugin:
                         return {"status": "ok", "message": "Stream matching cancelled by user."}
 
                     ch_name = entry["name"]
+                    entry_cc = self._resolve_entry_country(entry, cat_cc, logger)
                     ch_number = self._parse_channel_number(entry.get("number")) if use_number_boost else None
                     channel_id = existing_channels.get((ch_name, group_id))
 
@@ -2485,9 +2544,9 @@ class Plugin:
 
                     # Match streams using deduplicated names
                     matches = matcher.match_all_streams(
-                        ch_name, unique_stream_names, alias_map_for(cat_cc),
+                        ch_name, unique_stream_names, alias_map_for(entry_cc),
                         channel_number=ch_number,
-                        lineup_country=cat_cc,
+                        lineup_country=entry_cc,
                         quality_aware=(ch_name in upgrade_twin_set),
                     )
 
@@ -2811,8 +2870,6 @@ class Plugin:
                     continue
 
                 cat_cc = self._resolve_category_country(category, lineup_cc, logger)
-                # Lineup country first, then relaxed (None) if nothing matched.
-                countries = (cat_cc, None) if cat_cc else (None,)
 
                 for entry in channels:
                     if self._stop_event.is_set():
@@ -2820,6 +2877,9 @@ class Plugin:
                         return {"status": "ok", "message": "EPG matching cancelled by user."}
 
                     ch_name = entry["name"]
+                    entry_cc = self._resolve_entry_country(entry, cat_cc, logger)
+                    # Channel country first, then relaxed (None) if nothing matched.
+                    countries = (entry_cc, None) if entry_cc else (None,)
                     ch_number = self._parse_channel_number(entry.get("number")) if use_number_boost else None
                     ch_data = existing_channels.get((ch_name, group_id))
 
@@ -2849,7 +2909,7 @@ class Plugin:
                             if not pool:
                                 continue
                             ms = matcher.match_all_streams(
-                                ch_name, pool, alias_map_for(cat_cc),
+                                ch_name, pool, alias_map_for(entry_cc),
                                 channel_number=ch_number,
                                 lineup_country=country,
                             )
@@ -2859,13 +2919,13 @@ class Plugin:
                             top_entries = lookup.get(top_name, [])
                             if not top_entries:
                                 continue
-                            best_epg = self._pick_epg_by_country(top_entries, cat_cc)
+                            best_epg = self._pick_epg_by_country(top_entries, entry_cc)
                             best_score = top_score
                             best_method = top_method
                             has_program_data = has_prog
                             if not has_prog:
                                 logger.debug(f"{LOG_PREFIX} EPG fallback (no program data): {ch_name} -> {best_epg['name']}")
-                            if country is None and cat_cc:
+                            if country is None and entry_cc:
                                 logger.debug(f"{LOG_PREFIX} EPG country-relaxed match: {ch_name} -> {best_epg['name']}")
                             break
                         if best_epg:

--- a/Lineuparr/plugin.py
+++ b/Lineuparr/plugin.py
@@ -888,21 +888,52 @@ class Plugin:
         logger.info(f"{LOG_PREFIX} Loaded {len(streams)} streams" + (f" from {len(valid_ids)} M3U sources" if valid_ids else ""))
         return streams
 
-    def _build_alias_map(self, settings, logger):
+    def _alias_map_provider(self, settings, logger):
+        """Return a callable mapping a country code to that country's alias map.
+
+        A lineup can carry channels from several countries (a category named
+        "UK| Sports" inside a mixed lineup), and each needs the alias table for
+        ITS country, not for the lineup filename's country.
+
+        Memoized for the life of ONE run and no longer. The map depends on the
+        custom_aliases setting and on the selected lineup's embedded aliases,
+        both of which change between runs while the plugin object survives in a
+        long-lived worker process. Instance-level caching would serve a stale
+        map after a settings edit, and would carry one lineup's embedded aliases
+        into another lineup of the same country.
+        """
+        cache = {}
+
+        def alias_map_for(country):
+            key = (country or "").upper()
+            if key not in cache:
+                cache[key] = self._build_alias_map(settings, logger, country=key or None)
+            return cache[key]
+
+        return alias_map_for
+
+    def _build_alias_map(self, settings, logger, country=None):
         """Merge built-in aliases with user custom aliases.
 
         Built-in aliases are global (keyed by channel name). Country-scoped
-        overrides from COUNTRY_ALIASES are merged on top for THIS lineup's
-        country only, so a name that exists in multiple markets (e.g. "TLC",
-        "MTV") doesn't leak one country's stream-name variants into another
-        (bug-063). Custom user aliases are merged last and win.
+        overrides from COUNTRY_ALIASES are merged on top for ONE country only, so
+        a name that exists in multiple markets (e.g. "TLC", "MTV") does not leak
+        one country's stream-name variants into another (bug-063). Custom user
+        aliases are merged last and win.
+
+        The country defaults to the one in the lineup filename. Callers that know
+        a channel's own country (from its category name or its name prefix) pass
+        it explicitly, so a UK channel inside a US lineup gets UK aliases.
         """
         alias_map = dict(CHANNEL_ALIASES)
 
-        try:
-            lineup_cc, _ = self._parse_lineup_filename(settings.get("lineup_file", ""))
-        except Exception:
-            lineup_cc = None
+        if country:
+            lineup_cc = country
+        else:
+            try:
+                lineup_cc, _ = self._parse_lineup_filename(settings.get("lineup_file", ""))
+            except Exception:
+                lineup_cc = None
         if lineup_cc:
             for k, v in COUNTRY_ALIASES.get(lineup_cc.upper(), {}).items():
                 alias_map[k] = list(dict.fromkeys(alias_map.get(k, []) + list(v)))
@@ -1714,7 +1745,7 @@ class Plugin:
             if lineup.get("status") == "error":
                 return lineup
             matcher = self._init_fuzzy_matcher(settings, logger)
-            alias_map = self._build_alias_map(settings, logger)
+            alias_map_for = self._alias_map_provider(settings, logger)
             upgrade_twin_set = self._get_upgrade_twin_set(settings, lineup, matcher)
             streams = self._get_all_streams(settings, logger)
             assigner = self._init_assigner_state(settings)
@@ -1761,7 +1792,7 @@ class Plugin:
                     boost_number = self._parse_channel_number(entry.get("number")) if use_number_boost else None
 
                     matches = matcher.match_all_streams(
-                        ch_name, unique_stream_names, alias_map,
+                        ch_name, unique_stream_names, alias_map_for(cat_cc),
                         channel_number=boost_number,
                         lineup_country=cat_cc,
                         quality_aware=(ch_name in upgrade_twin_set),
@@ -2384,7 +2415,7 @@ class Plugin:
                 return lineup
             prefix = self._get_group_prefix(settings, lineup)
             matcher = self._init_fuzzy_matcher(settings, logger)
-            alias_map = self._build_alias_map(settings, logger)
+            alias_map_for = self._alias_map_provider(settings, logger)
             rate_limiter = SmartRateLimiter(settings.get("rate_limiting", PluginConfig.DEFAULT_RATE_LIMITING))
             lineup_cc, _ = self._parse_lineup_filename(settings.get("lineup_file", ""))
             if lineup_cc:
@@ -2454,7 +2485,7 @@ class Plugin:
 
                     # Match streams using deduplicated names
                     matches = matcher.match_all_streams(
-                        ch_name, unique_stream_names, alias_map,
+                        ch_name, unique_stream_names, alias_map_for(cat_cc),
                         channel_number=ch_number,
                         lineup_country=cat_cc,
                         quality_aware=(ch_name in upgrade_twin_set),
@@ -2693,7 +2724,7 @@ class Plugin:
                 return lineup
             prefix = self._get_group_prefix(settings, lineup)
             matcher = self._init_fuzzy_matcher(settings, logger)
-            alias_map = self._build_alias_map(settings, logger)
+            alias_map_for = self._alias_map_provider(settings, logger)
             rate_limiter = SmartRateLimiter(settings.get("rate_limiting", PluginConfig.DEFAULT_RATE_LIMITING))
 
             # Extract lineup country code for EPG country matching
@@ -2818,7 +2849,7 @@ class Plugin:
                             if not pool:
                                 continue
                             ms = matcher.match_all_streams(
-                                ch_name, pool, alias_map,
+                                ch_name, pool, alias_map_for(cat_cc),
                                 channel_number=ch_number,
                                 lineup_country=country,
                             )

--- a/README.md
+++ b/README.md
@@ -229,6 +229,35 @@ Create your own lineup JSON files following this format:
 
 Place the file in the plugin directory and it will appear in the **Lineup File** dropdown.
 
+### Per-channel aliases
+
+A channel entry may carry its own `aliases` array. These are merged with the built-in alias table for that lineup only, which is the right place for stream-name variants that are specific to one provider:
+
+```json
+{ "name": "My9 New York", "number": 509, "aliases": ["WWOR", "WWOR-TV", "MY9"] }
+```
+
+When an alias is a US broadcast callsign, a stream carrying that callsign anywhere in its name matches, so `WWOR` reaches `US: MY 9 WWOR NEW YORK` and `CITY: MNT WWOR NEW YORK`. Ordinary words that look like callsigns (KIDS, WORLD, WOMEN, WEST) are excluded, so they never pull in unrelated streams.
+
+### Foreign channels inside a single-country lineup
+
+Matching is normally restricted to the lineup's own country, which is what stops a Canadian feed attaching to a US channel. Two ways to mark a channel that belongs to a different country:
+
+**A country prefix on the channel name.** Name the channel `{CC}_{Name}` and it is matched against that country instead, wherever it sits in the lineup:
+
+```json
+"International": [
+  { "name": "UK_CNN", "number": 501 },
+  { "name": "FR_TF1", "number": 502 }
+]
+```
+
+The prefix is stripped before anything else sees it, so Dispatcharr creates the channel as `CNN`, not `UK_CNN`. Only recognized country codes count, so an ordinary name containing an underscore is left alone. Each marked channel also gets that country's aliases.
+
+**A country prefix on the category name.** A whole category can be marked instead, using `UK| International`, `UK: International` or `UK International`. Use this when the foreign channels are already grouped together.
+
+A channel's own prefix wins over its category's, which wins over the lineup filename.
+
 ## Custom Aliases
 
 Override or extend the built-in alias table using the **Custom Channel Aliases (JSON)** setting. Paste a JSON object where keys are the **exact lineup channel name** (as it appears in the lineup JSON) and values are arrays of alternate names your IPTV provider uses for that channel (a single alias may also be given as a plain string instead of a one-item array):


### PR DESCRIPTION
Lets a lineup carry channels from more than one country, and fixes an alias defect found while designing it. Three commits, reviewable in order.

## 1. Alias maps follow the channel's country, not the lineup filename

`_build_alias_map` merged `COUNTRY_ALIASES` for the country in the lineup FILENAME only. Lineuparr already lets a category name carry a country code (`UK| Sports` inside a mixed lineup) and passes that per-category code to the matcher, so a UK channel in a US lineup was matched with US aliases. That is a defect against the shipped per-category feature, so it lands first and on its own.

`_build_alias_map` now takes an optional country and falls back to the filename when none is given. A new `_alias_map_provider` builds and memoizes one map per country, and the three matching loops ask it for the map belonging to the channel's resolved country.

The memoization is scoped to one run and deliberately not stored on the plugin object: the map depends on the `custom_aliases` setting and on the selected lineup's embedded aliases, both of which change between runs while the plugin object survives in a long-lived worker process.

## 2. Per-channel country from a `CC_` name prefix

A channel named `UK_CNN` inside a US lineup is matched against UK streams and gets UK aliases, while every other channel stays US:

```json
"International": [
  { "name": "UK_CNN", "number": 501 },
  { "name": "FR_TF1", "number": 502 }
]
```

This covers what the category prefix cannot, an individual channel wherever it sits, and removes the reason to select a combined multi-country lineup (which gives up country filtering almost entirely) just to carry a few foreign channels.

- `detect_name_country_prefix` in `fuzzy_matcher.py` splits the prefix off, beside `detect_category_country` because both answer the same question from a different string and both need the country vocabulary private to that module. Only recognized country codes count, so `MTV_Live` is left alone, and a name with nothing after the prefix is not turned into an empty channel name.
- The rewrite happens once in `_load_lineup`, before anything else sees the lineup and before the category-detail transformation. The name is used for channel creation, matching, reports and EPG matching, so a prefix left in place would have to be stripped correctly in several unrelated places. Dispatcharr creates the channel as `CNN`.
- `_resolve_entry_country` resolves one channel's country: its own, then its category's, then the lineup filename's. An override is logged, mirroring `_resolve_category_country` one level up.
- Country was previously resolved once per category. All four consumers now use the per-channel value: the preview loop, the apply-stream-match loop, and in the apply-EPG-match loop both the country tuple and the `_pick_epg_by_country` call. That last one sits inside the channel loop but read the category variable, so it is the one a partial implementation would miss.

## 3. README

Documents the per-channel `aliases` array, both country-prefix forms, and the precedence between them.

## Verification

- 48 new tests; suite at 536 passing, from 489 before this work.
- Static plugin validation, vendored-core parity and matcher golden drift gates pass.
- `ruff check` reports the same 17 pre-existing findings on the two edited files as on `main`; none added.
- Mutation testing on a scratch copy: nine deliberate breakages were each caught, including reverting the EPG source preference to the category country and disabling the load-time rewrite, with a no-op control surviving. Two first-draft tests let a mutation through and were strengthened.
- Measured before implementing: no channel name in any of the 15 shipped lineup files contains an underscore, so no shipped lineup is affected by the prefix rule.

## Limitations, stated deliberately

The country filter drops streams whose name carries a wrong country marker and keeps streams with no marker at all, because over-filtering breaks sources that do not tag country. A `UK_` marked channel therefore remains eligible for an untagged stream. This decides which country to filter for; it cannot make the filter more confident than its input.

The prefix rule fires on any of the 26 recognized country codes. The exposure is a user-authored lineup with a channel named `<code>_<something>`, and it widens automatically if that code set grows. The override log line is what makes such a rewrite visible.

Not yet done: no version bump, and none of this has run inside a Dispatcharr container.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QVyYBWwJS3HAv18aT8xyNN
