### PR TITLE
Add custom logo repository action

### DIFF
--- a/Lineuparr/logo_matcher.py
+++ b/Lineuparr/logo_matcher.py
@@ -190,15 +190,16 @@ def fetch_logo_filelist(repo, branch, directory):
     if not re.fullmatch(r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+", repo):
         LOGGER.warning("Invalid GitHub repository name: %r", repo)
         return []
-    if not branch or not directory or any(
+    if not branch or (directory and any(
         part in ("", ".", "..") for part in directory.split("/")
-    ):
+    )):
         LOGGER.warning("Invalid GitHub branch or logo directory")
         return []
 
     encoded_dir = urllib.parse.quote(directory, safe="/")
     query = urllib.parse.urlencode({"ref": branch})
-    url = f"https://api.github.com/repos/{repo}/contents/{encoded_dir}?{query}"
+    contents_path = f"/contents/{encoded_dir}" if encoded_dir else "/contents"
+    url = f"https://api.github.com/repos/{repo}{contents_path}?{query}"
     try:
         req = urllib.request.Request(
             url, headers={"Accept": "application/vnd.github.v3+json"}
@@ -224,12 +225,36 @@ def fetch_logo_filelist(repo, branch, directory):
         return []
 
 
+def resolve_repository_branch(repo, branch=""):
+    """Return an explicit branch or discover the repository's default branch."""
+    branch = (branch or "").strip().strip("/")
+    if branch:
+        return branch
+    repo = (repo or "").strip().strip("/")
+    if not re.fullmatch(r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+", repo):
+        return None
+    url = f"https://api.github.com/repos/{repo}"
+    try:
+        req = urllib.request.Request(
+            url, headers={"Accept": "application/vnd.github.v3+json"}
+        )
+        with urllib.request.urlopen(req, timeout=15) as resp:
+            data = json.loads(resp.read().decode())
+        default_branch = str(data.get("default_branch", "")).strip()
+        return default_branch or None
+    except Exception as e:
+        LOGGER.warning("Failed to resolve default branch for %s: %s", repo, e)
+        return None
+
+
 def build_repository_logo_url(repo, branch, directory, filename):
     """Build a raw GitHub URL for an image in a repository directory."""
+    raw_path = "/".join(
+        part for part in (branch.strip("/"), directory.strip("/"), filename)
+        if part
+    )
     path = "/".join(
         urllib.parse.quote(part, safe="")
-        for part in (
-            branch.strip("/") + "/" + directory.strip("/") + "/" + filename
-        ).split("/")
+        for part in raw_path.split("/")
     )
     return f"https://raw.githubusercontent.com/{repo.strip().strip('/')}/{path}"

--- a/Lineuparr/logo_matcher.py
+++ b/Lineuparr/logo_matcher.py
@@ -7,8 +7,10 @@ comparing clean channel names against structured filenames.
 
 import re
 import urllib.request
+import urllib.parse
 import json
 import logging
+import unicodedata
 
 try:
     from rapidfuzz import fuzz
@@ -130,3 +132,104 @@ def fetch_tv_logos_filelist(repo, branch, country_dir):
 def build_logo_url(repo, branch, country_dir, filename):
     """Build a raw GitHub URL for a logo file."""
     return f"https://raw.githubusercontent.com/{repo}/{branch}/countries/{country_dir}/{filename}"
+
+
+# The helpers below are used only by the standalone custom-logo action. The
+# original tv-logos matching functions above intentionally remain unchanged.
+def _normalize_repository_logo_name(name, country_suffix=None):
+    """Normalize a custom repository filename or Dispatcharr channel name."""
+    name = unicodedata.normalize('NFC', str(name)).lower().strip()
+    name = re.sub(r'\.(png|svg|jpg|jpeg|gif|webp)$', '', name, flags=re.IGNORECASE)
+    if country_suffix:
+        name = re.sub(
+            rf'[-._]{re.escape(country_suffix)}$', '', name, flags=re.IGNORECASE
+        )
+    name = name.replace('-', ' ').replace('_', ' ')
+    name = name.replace('&', ' and ').replace('+', ' plus ')
+    name = re.sub(r'[^\w\s]', '', name)
+    # East is treated as the standard feed; Pacific remains a distinct name.
+    name = re.sub(r'\s+east\s*$', '', name)
+    name = re.sub(r'\s+(hd|sd|uhd|4k|fhd)\s*$', '', name)
+    return re.sub(r'\s+', ' ', name).strip()
+
+
+def match_channel_to_repository_logo(
+    channel_name, logo_filenames, country_suffix, threshold=90
+):
+    """Match a channel only against the standalone repository logo library."""
+    normalized_channel = _normalize_repository_logo_name(channel_name)
+    if not normalized_channel:
+        return None
+
+    country_pattern = re.compile(
+        rf'[-._]{re.escape(country_suffix)}\.(png|svg|jpg|jpeg|gif|webp)$',
+        flags=re.IGNORECASE,
+    )
+    country_files = [name for name in logo_filenames if country_pattern.search(name)]
+    candidates = country_files or logo_filenames
+    best_score = 0
+    best_file = None
+    for filename in candidates:
+        normalized_logo = _normalize_repository_logo_name(filename, country_suffix)
+        if not normalized_logo:
+            continue
+        score = fuzz.ratio(normalized_channel, normalized_logo)
+        if score > best_score:
+            best_score = score
+            best_file = filename
+            if best_score == 100:
+                break
+    return best_file if best_score >= threshold else None
+
+
+def fetch_logo_filelist(repo, branch, directory):
+    """Fetch image filenames from an arbitrary public GitHub directory."""
+    repo = (repo or "").strip().strip("/")
+    branch = (branch or "").strip().strip("/")
+    directory = (directory or "").strip().strip("/")
+    if not re.fullmatch(r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+", repo):
+        LOGGER.warning("Invalid GitHub repository name: %r", repo)
+        return []
+    if not branch or not directory or any(
+        part in ("", ".", "..") for part in directory.split("/")
+    ):
+        LOGGER.warning("Invalid GitHub branch or logo directory")
+        return []
+
+    encoded_dir = urllib.parse.quote(directory, safe="/")
+    query = urllib.parse.urlencode({"ref": branch})
+    url = f"https://api.github.com/repos/{repo}/contents/{encoded_dir}?{query}"
+    try:
+        req = urllib.request.Request(
+            url, headers={"Accept": "application/vnd.github.v3+json"}
+        )
+        with urllib.request.urlopen(req, timeout=15) as resp:
+            data = json.loads(resp.read().decode())
+        if not isinstance(data, list):
+            LOGGER.warning("Unexpected GitHub API response for %s", directory)
+            return []
+        if len(data) >= 1000:
+            LOGGER.warning(
+                "GitHub API returned %s entries for %s; results may be truncated",
+                len(data), directory,
+            )
+        image_exts = ('.png', '.svg', '.jpg', '.jpeg', '.gif', '.webp')
+        return [
+            item['name'] for item in data
+            if item.get('type') == 'file'
+            and item.get('name', '').lower().endswith(image_exts)
+        ]
+    except Exception as e:
+        LOGGER.warning("Failed to fetch custom logo list for %s: %s", directory, e)
+        return []
+
+
+def build_repository_logo_url(repo, branch, directory, filename):
+    """Build a raw GitHub URL for an image in a repository directory."""
+    path = "/".join(
+        urllib.parse.quote(part, safe="")
+        for part in (
+            branch.strip("/") + "/" + directory.strip("/") + "/" + filename
+        ).split("/")
+    )
+    return f"https://raw.githubusercontent.com/{repo.strip().strip('/')}/{path}"

--- a/Lineuparr/plugin.json
+++ b/Lineuparr/plugin.json
@@ -90,6 +90,17 @@
       }
     },
     {
+      "id": "assign_custom_logos",
+      "label": "Assign Custom Logos",
+      "button_label": "🖼️ Assign Custom Logos",
+      "description": "Assign logos from the configured public GitHub directory directly to all existing Dispatcharr channels; no lineup sync required",
+      "button_variant": "filled",
+      "button_color": "blue",
+      "confirm": {
+        "message": "Match custom repository logos against all existing Dispatcharr channels?"
+      }
+    },
+    {
       "id": "resort_streams",
       "label": "Re-sort Streams by Quality",
       "button_label": "⭐ Re-sort",

--- a/Lineuparr/plugin.py
+++ b/Lineuparr/plugin.py
@@ -104,6 +104,7 @@ class PluginConfig:
 
     TV_LOGOS_REPO = "tv-logo/tv-logos"
     TV_LOGOS_BRANCH = "main"
+    CUSTOM_LOGO_MATCH_THRESHOLD = 90
 
     DATA_DIR = "/data"
     EXPORTS_DIR = "/data/exports"
@@ -501,6 +502,28 @@ class Plugin:
                 "placeholder": "{\"Channel Name\": [\"alias 1\", \"alias 2\"]}",
                 "help_text": "JSON object mapping a lineup channel name to extra alias names (a bare string is accepted as a single alias). Leave blank to use built-in aliases only.",
             },
+            # --- Section: Custom Logos ---
+            {
+                "id": "_sec_custom_logos",
+                "type": "info",
+                "label": "Custom Logo Repository",
+                "help_text": "Assign logos from an optional public GitHub directory directly to existing Dispatcharr channels. This does not require a lineup sync.",
+            },
+            {
+                "id": "custom_logo_source",
+                "label": "GitHub Logo Source",
+                "type": "string",
+                "default": "",
+                "placeholder": "owner/repository@main:path/to/logos",
+                "help_text": "Public GitHub directory in owner/repository@branch:path format. Example: example/media@main:logos/channels. Leave blank to disable custom repository matching.",
+            },
+            {
+                "id": "custom_logo_replace_existing",
+                "label": "Replace Existing Logos When Matched",
+                "type": "boolean",
+                "default": False,
+                "help_text": "When on, a custom repository match replaces the channel's current logo. Existing logos are preserved when the custom repository has no match.",
+            },
             # --- Section: Notifications ---
             {
                 "id": "_sec_notify",
@@ -574,6 +597,7 @@ class Plugin:
                 "sync_channels": self._sync_channels,
                 "apply_stream_match": self._apply_stream_match,
                 "apply_epg_match": self._apply_epg_match,
+                "assign_custom_logos": self._assign_custom_logos,
                 "apply_logo_match": self._apply_logo_match,
                 "resort_streams": self._resort_streams,
                 "clear_csv_exports": self._clear_csv_exports,
@@ -2369,6 +2393,167 @@ class Plugin:
             "message": f"Logo assignment started for {total_channels} channels. ETA: ~{eta_str}. Click 📊 Status to watch progress.",
             "background": True,
         }
+
+    def _assign_custom_logos(self, settings, logger):
+        """Assign repository logos to all existing Dispatcharr channels."""
+        if not _LOGO_AVAILABLE:
+            return {"status": "error", "message": "Logo model not available in this Dispatcharr installation."}
+
+        source, source_error = self._parse_custom_logo_source(settings)
+        if source_error:
+            return {"status": "error", "message": source_error}
+
+        total_channels = Channel.objects.count()
+        eta_seconds = total_channels * PluginConfig.ESTIMATED_SECONDS_PER_LOGO_MATCH
+        eta_str = ProgressTracker._format_eta_static(eta_seconds)
+        if not self._try_start_thread(
+            self._do_assign_custom_logos_bg, (dict(settings), logger)
+        ):
+            return {"status": "error", "message": "An operation is already running. Please wait for it to finish."}
+        return {
+            "status": "ok",
+            "message": (
+                f"Custom logo assignment started for {total_channels} existing channels. "
+                f"ETA: ~{eta_str}. Click 📊 Status to watch progress."
+            ),
+            "background": True,
+        }
+
+    @staticmethod
+    def _parse_custom_logo_source(settings):
+        """Parse owner/repository@branch:path/to/logos from plugin settings."""
+        raw = str(settings.get("custom_logo_source", "") or "").strip()
+        if not raw:
+            return None, "GitHub Logo Source is blank. Configure a source before running this action."
+        match = re.fullmatch(
+            r"([A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)@([^:]+):(.+)", raw
+        )
+        if not match:
+            return None, (
+                "Invalid GitHub Logo Source. Use "
+                "owner/repository@branch:path/to/logos."
+            )
+        repo, branch, directory = (part.strip().strip("/") for part in match.groups())
+        if not repo or not branch or not directory:
+            return None, "GitHub Logo Source contains an empty repository, branch, or path."
+        return (repo, branch, directory), None
+
+    def _custom_logo_country(self, channel, settings):
+        """Infer the two-letter logo suffix from channel/group prefixes."""
+        group_name = channel.channel_group.name if channel.channel_group else ""
+        for value in (group_name, channel.name):
+            match = re.match(r"^([A-Z]{2})\s*[|:]", value, flags=re.IGNORECASE)
+            if match:
+                return match.group(1).lower()
+        try:
+            lineup_cc, _ = self._parse_lineup_filename(settings.get("lineup_file", ""))
+        except Exception:
+            lineup_cc = None
+        return lineup_cc.lower() if lineup_cc else "us"
+
+    def _do_assign_custom_logos_bg(self, settings, logger):
+        """Background wrapper for standalone custom logo assignment."""
+        try:
+            result = self._do_assign_custom_logos(settings, logger)
+            msg = result.get("message", "Custom logo assignment complete.")
+            logger.info(f"{LOG_PREFIX} CUSTOM LOGO MATCH COMPLETED: {msg}")
+            send_websocket_update('updates', 'update', {
+                "type": "plugin", "plugin": "Lineuparr", "message": msg
+            })
+        except Exception as e:
+            logger.exception(f"{LOG_PREFIX} Custom logo assignment error: {e}")
+            send_websocket_update('updates', 'update', {
+                "type": "plugin", "plugin": "Lineuparr",
+                "message": f"Custom logo assignment error: {e}"
+            })
+
+    def _do_assign_custom_logos(self, settings, logger):
+        """Assign custom logos without changing lineups, streams, or EPG data."""
+        if not self._acquire_lock(logger):
+            return {"status": "error", "message": "Another operation is in progress. Try again later."}
+
+        try:
+            from .logo_matcher import (
+                fetch_logo_filelist, match_channel_to_repository_logo,
+                build_repository_logo_url,
+            )
+
+            source, source_error = self._parse_custom_logo_source(settings)
+            if source_error:
+                return {"status": "error", "message": source_error}
+            repo, branch, directory = source
+            files = fetch_logo_filelist(repo, branch, directory)
+            if not files:
+                return {
+                    "status": "error",
+                    "message": f"No logo files found at {repo}@{branch}/{directory}.",
+                }
+
+            channels = list(Channel.objects.select_related('channel_group', 'logo').all())
+            progress = ProgressTracker(len(channels), "assign_custom_logos", logger)
+            replace_existing = bool(settings.get("custom_logo_replace_existing", False))
+            logos_by_url = {logo.url: logo for logo in Logo.objects.all()}
+
+            assigned = 0
+            unchanged = 0
+            skipped_existing = 0
+            no_match = 0
+            channels_to_update = []
+
+            for channel in channels:
+                if self._stop_event.is_set():
+                    return {"status": "ok", "message": "Custom logo assignment cancelled by user."}
+
+                if channel.logo_id is not None and not replace_existing:
+                    skipped_existing += 1
+                    progress.update()
+                    continue
+
+                country_suffix = self._custom_logo_country(channel, settings)
+                match_name = re.sub(
+                    r"^[A-Z]{2}\s*[|:]\s*", "", channel.name,
+                    flags=re.IGNORECASE,
+                )
+                matched_file = match_channel_to_repository_logo(
+                    match_name, files, country_suffix,
+                    threshold=PluginConfig.CUSTOM_LOGO_MATCH_THRESHOLD,
+                )
+                if not matched_file:
+                    no_match += 1
+                    progress.update()
+                    continue
+
+                raw_url = build_repository_logo_url(
+                    repo, branch, directory, matched_file
+                )
+                logo = logos_by_url.get(raw_url)
+                if not logo:
+                    logo = Logo.objects.create(name=match_name, url=raw_url)
+                    logos_by_url[raw_url] = logo
+
+                if channel.logo_id == logo.id:
+                    unchanged += 1
+                else:
+                    channel.logo = logo
+                    channels_to_update.append(channel)
+                    assigned += 1
+                progress.update()
+
+            if channels_to_update:
+                with transaction.atomic():
+                    Channel.objects.bulk_update(channels_to_update, ['logo_id'])
+
+            progress.finish()
+            self._trigger_frontend_refresh(logger)
+            msg = (
+                f"Custom logo assignment complete: {assigned} changed, "
+                f"{unchanged} already current, {skipped_existing} existing preserved, "
+                f"{no_match} no custom match"
+            )
+            logger.info(f"{LOG_PREFIX} {msg}")
+            return {"status": "ok", "message": msg}
+        finally:
+            self._release_lock(logger)
 
     def _do_apply_logo_match_bg(self, settings, logger):
         """Background wrapper for logo assignment."""

--- a/Lineuparr/plugin.py
+++ b/Lineuparr/plugin.py
@@ -514,8 +514,8 @@ class Plugin:
                 "label": "GitHub Logo Source",
                 "type": "string",
                 "default": "",
-                "placeholder": "owner/repository@main:path/to/logos",
-                "help_text": "Public GitHub directory in owner/repository@branch:path format. Example: example/media@main:logos/channels. Leave blank to disable custom repository matching.",
+                "placeholder": "owner/repository:path/to/logos",
+                "help_text": "Public GitHub repository, optionally followed by :path/to/logos. The default branch is used automatically. Advanced: owner/repository@branch:path. Leave blank to disable.",
             },
             {
                 "id": "custom_logo_replace_existing",
@@ -2421,21 +2421,24 @@ class Plugin:
 
     @staticmethod
     def _parse_custom_logo_source(settings):
-        """Parse owner/repository@branch:path/to/logos from plugin settings."""
+        """Parse owner/repository with optional branch and directory."""
         raw = str(settings.get("custom_logo_source", "") or "").strip()
         if not raw:
             return None, "GitHub Logo Source is blank. Configure a source before running this action."
         match = re.fullmatch(
-            r"([A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)@([^:]+):(.+)", raw
+            r"([A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)"
+            r"(?:@([^:]+))?(?::(.+))?",
+            raw,
         )
         if not match:
             return None, (
                 "Invalid GitHub Logo Source. Use "
+                "owner/repository, owner/repository:path/to/logos, or "
                 "owner/repository@branch:path/to/logos."
             )
-        repo, branch, directory = (part.strip().strip("/") for part in match.groups())
-        if not repo or not branch or not directory:
-            return None, "GitHub Logo Source contains an empty repository, branch, or path."
+        repo = match.group(1).strip().strip("/")
+        branch = (match.group(2) or "").strip().strip("/")
+        directory = (match.group(3) or "").strip().strip("/")
         return (repo, branch, directory), None
 
     def _custom_logo_country(self, channel, settings):
@@ -2475,18 +2478,24 @@ class Plugin:
         try:
             from .logo_matcher import (
                 fetch_logo_filelist, match_channel_to_repository_logo,
-                build_repository_logo_url,
+                build_repository_logo_url, resolve_repository_branch,
             )
 
             source, source_error = self._parse_custom_logo_source(settings)
             if source_error:
                 return {"status": "error", "message": source_error}
             repo, branch, directory = source
+            branch = resolve_repository_branch(repo, branch)
+            if not branch:
+                return {
+                    "status": "error",
+                    "message": f"Could not determine the default branch for {repo}.",
+                }
             files = fetch_logo_filelist(repo, branch, directory)
             if not files:
                 return {
                     "status": "error",
-                    "message": f"No logo files found at {repo}@{branch}/{directory}.",
+                    "message": f"No logo files found in the configured directory for {repo}.",
                 }
 
             channels = list(Channel.objects.select_related('channel_group', 'logo').all())

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Before installing or using this plugin, it is **highly recommended** that you cr
 - **Single-Channel Targeting:** Optionally scope stream, EPG, and logo matching to one named lineup channel instead of the whole lineup
 - **EPG Assignment:** Fuzzy-match EPG data to channels and assign program guides from any configured EPG source
 - **Logo Assignment:** Auto-assign channel logos from EPG icons, Logo Manager, or the [tv-logos](https://github.com/tv-logo/tv-logos) GitHub repository
+- **Custom Logo Repository:** Match all existing Dispatcharr channels against an optional public GitHub logo directory without running a lineup sync
 - **Quality Ordering:** Automatically sort matched streams by quality (4K > UHD > FHD > HD > SD) using name-based detection or [IPTV Checker](https://github.com/PiratesIRC/Dispatcharr-IPTV-Checker-Plugin) metadata
 - **Channel Number Preservation:** Lineup channel numbers are stored and used for tiebreaking during matching
 - **East/West/Pacific Filtering:** Regional channel variants are matched to the correct regional streams

--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -60,6 +60,8 @@ tells you whether your match sensitivity is set sensibly for your source.
 | Rate Limiting | select | `None` | Throttles between operations: None, Low, Medium or High. Use it if a large sync makes Dispatcharr sluggish. |
 | Custom Channel Aliases (JSON) | string | *(empty)* | Your own alias overrides. See [Custom aliases](#custom-aliases). |
 | EPG Sources | select | `All EPG sources` | Which EPG source or sources to match against. "All" uses every source in the priority order configured in Dispatcharr. |
+| GitHub Logo Source | string | *(empty)* | Optional public logo directory in `owner/repository@branch:path/to/logos` format. Used only by Assign Custom Logos. |
+| Replace Existing Logos When Matched | boolean | `false` | Allows a successful custom repository match to replace a channel's current logo. Channels with no match keep their current logo. |
 
 ---
 
@@ -137,12 +139,39 @@ live on the Actions tab of the plugin panel:
 | **Apply Stream Match Only** | Attaches matched streams to channels that already exist, in quality order. |
 | **Apply EPG Match** | Matches EPG entries to channels and assigns the programme guides. |
 | **Assign Logos** | Assigns channel logos from EPG icons, the Logo Manager, or the tv-logos repository on GitHub. |
+| **Assign Custom Logos** | Matches the configured public GitHub logo directory against every existing Dispatcharr channel. It does not run a lineup sync or alter streams or EPG assignments. |
 | **Re-sort Streams by Quality** | Re-orders already-attached streams using the newest quality data. See [IPTV Checker integration](#iptv-checker-integration). |
 | **Clear CSV Exports** | Deletes the plugin's CSV exports. |
 
 **Single Channel Match** scopes Preview Stream Match, Apply Stream Match Only,
 Apply EPG Match and Assign Logos to one channel. Full Sync always runs the whole
 lineup regardless of that setting.
+
+---
+
+## Custom logo repository
+
+Set **GitHub Logo Source** to a public directory using this format:
+
+```text
+owner/repository@branch:path/to/logos
+```
+
+For example, `example/media@main:logos/channels` reads image files from the
+`logos/channels` directory on the `main` branch. The field is empty by default,
+and the plugin does not include or prefer any particular repository.
+
+Logo filenames should describe the channel with words separated by hyphens or
+underscores. An optional two-letter country suffix limits a file to that
+country, such as `example-news-us.png` or `example-sports-gb.png`. Supported
+extensions are PNG, SVG, JPG, JPEG, GIF and WebP. East is treated as the
+standard feed, while Pacific remains a distinct filename term.
+
+Run **Assign Custom Logos** independently from the other actions. It examines
+all existing Dispatcharr channels and changes only their logo reference. With
+**Replace Existing Logos When Matched** off, channels that already have a logo
+are skipped. With it on, an existing logo is replaced only when the repository
+contains a match. A channel with no match is never cleared.
 
 ---
 

--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -60,7 +60,7 @@ tells you whether your match sensitivity is set sensibly for your source.
 | Rate Limiting | select | `None` | Throttles between operations: None, Low, Medium or High. Use it if a large sync makes Dispatcharr sluggish. |
 | Custom Channel Aliases (JSON) | string | *(empty)* | Your own alias overrides. See [Custom aliases](#custom-aliases). |
 | EPG Sources | select | `All EPG sources` | Which EPG source or sources to match against. "All" uses every source in the priority order configured in Dispatcharr. |
-| GitHub Logo Source | string | *(empty)* | Optional public logo directory in `owner/repository@branch:path/to/logos` format. Used only by Assign Custom Logos. |
+| GitHub Logo Source | string | *(empty)* | Public repository with an optional logo directory, such as `owner/repository:path/to/logos`. The default branch is automatic. Used only by Assign Custom Logos. |
 | Replace Existing Logos When Matched | boolean | `false` | Allows a successful custom repository match to replace a channel's current logo. Channels with no match keep their current logo. |
 
 ---
@@ -151,15 +151,24 @@ lineup regardless of that setting.
 
 ## Custom logo repository
 
-Set **GitHub Logo Source** to a public directory using this format:
+Set **GitHub Logo Source** to a public repository. If its logos are in the
+repository root, only the owner and repository are needed:
 
 ```text
-owner/repository@branch:path/to/logos
+owner/repository
 ```
 
-For example, `example/media@main:logos/channels` reads image files from the
-`logos/channels` directory on the `main` branch. The field is empty by default,
-and the plugin does not include or prefer any particular repository.
+Add a colon and directory when the logo files are in a subdirectory:
+
+```text
+owner/repository:path/to/logos
+```
+
+For example, `example/media:logos/channels` reads image files from the
+`logos/channels` directory on the repository's default branch. A non-default
+branch can be selected with the advanced form
+`owner/repository@branch:path/to/logos`. The field is empty by default, and the
+plugin does not include or prefer any particular repository.
 
 Logo filenames should describe the channel with words separated by hyphens or
 underscores. An optional two-letter country suffix limits a file to that


### PR DESCRIPTION
## What changed

- add an optional, blank-by-default public GitHub logo source using `owner/repository` or `owner/repository:path/to/logos`, with automatic default-branch discovery
- add a standalone **Assign Custom Logos** action that runs against existing Dispatcharr channels without requiring a lineup sync
- preserve existing logos by default, with an explicit option to replace only when a repository match is found
- add an isolated repository matcher with country suffix filtering, Unicode normalization, East/standard handling, Pacific distinction, and safe URL encoding
- document the settings, filename convention, supported image formats, and non-destructive behavior

## Scope

The action changes only channel logo references and creates reusable Logo records when needed. It does not alter lineups, channel names, streams, EPG assignments, channel groups, or the existing Assign Logos pipeline. No repository is built in or preferred.

## Validation

- `python3 .github/scripts/validate_plugin.py`
- `python3 .github/scripts/check_core_parity.py`
- `python3 .github/scripts/check_client_parity.py`
- `python3 .github/scripts/check_matcher_golden.py`
- focused checks for root and nested directories, automatic default-branch discovery, optional slash-containing branches, invalid settings, country suffixes, accents, plus signs, East/standard, Pacific, and URL encoding
- verified that existing logo matcher functions are unchanged
