### PR TITLE
Add channel-scoped excluded aliases

### DIFF
--- a/.github/scripts/check_matcher_golden.py
+++ b/.github/scripts/check_matcher_golden.py
@@ -118,7 +118,7 @@ def run_corpus(matcher, parse_excluded_aliases):
     out["excluded_aliases"]["normalized_variant_positive"] = _safe(
         matcher.match_all_streams, "REELZ", ["US | Reelz Channel HD"], {}
     )
-    out["excluded_aliases"]["normalized_variant"] = _safe(
+    out["excluded_aliases"]["unlisted_full_name_survives"] = _safe(
         matcher.match_all_streams, "REELZ", ["US | Reelz Channel HD"], {},
         excluded_aliases=["ReelzChannel"],
     )
@@ -129,7 +129,7 @@ def run_corpus(matcher, parse_excluded_aliases):
         matcher.match_all_streams, "Example", ["US: Example 4K"], quality_aliases,
         quality_aware=True,
     )
-    out["excluded_aliases"]["quality_bypass_blocked"] = _safe(
+    out["excluded_aliases"]["unlisted_quality_prefix_survives"] = _safe(
         matcher.match_all_streams, "Example", ["US: Example 4K"], quality_aliases,
         quality_aware=True, excluded_aliases=["Example 4K"],
     )
@@ -170,12 +170,80 @@ def load_matcher():
     return mod.FuzzyMatcher(), mod.parse_excluded_aliases
 
 
+def check_exclusion_regressions(matcher, parse_exclusions):
+    """Assert survivor identities independently of the recorded golden outputs."""
+    cases = [
+        ("Game Show Network", ["Game Show Central"],
+         ["Game Show Central", "Game Show Network", "Game Show Network HD"], ["Game Show Central"]),
+        ("Game Show Network", ["*Game Show Central*"],
+         ["US: Game Show Central HD", "GAME  SHOW CENTRAL", "Game Show Network",
+          "Game Show Network HD", "GameShowCentral"], ["US: Game Show Central HD", "GAME  SHOW CENTRAL"]),
+        ("REELZ", ["US-ReelzChannel"],
+         ["US-ReelzChannel", "REELZ", "Reelz Channel", "Reelz HD"], ["US-ReelzChannel"]),
+        ("NFL Network", ["NFL Channel"],
+         ["NFL Channel", "NFL Network", "US: NFL Channel HD"], ["NFL Channel"]),
+        ("Example", ["  uS:   Example  "],
+         ["US: Example", "US: Example HD", "Example"], ["US: Example"]),
+        ("Example", [r"M\*A\*S\*H"],
+         ["M*A*S*H", "MASH", "MxxAxxSxxH"], ["M*A*S*H"]),
+        ("Example", [r"US\\M\*A\*S\*H"],
+         [r"US\M*A*S*H", r"US\MASH"], [r"US\M*A*S*H"]),
+        ("Example", ["US:*Backup"],
+         ["US: Example Backup", "US: Example Backup HD", "Example Backup"], ["US: Example Backup"]),
+        ("Example", ["Example ? [HD]"],
+         ["Example ? [HD]", "Example X H", "Example"], ["Example ? [HD]"]),
+        ("Example", ["*", "**", " * * "],
+         ["Example", "Example HD"], []),
+    ]
+    for channel, excluded, candidates, blocked in cases:
+        aliases = {channel: candidates}
+        before = matcher.match_all_streams(channel, candidates, aliases)
+        before_names = {m[0] for m in before}
+        assert set(blocked) <= before_names, (channel, "bad test pool")
+        assert before_names - set(blocked), (channel, "no positive survivor")
+        after = matcher.match_all_streams(channel, candidates, aliases, excluded_aliases=excluded)
+        assert after == [m for m in before if m[0] not in blocked], (channel, excluded, after)
+        # No leakage into another channel or a later no-exclusions call.
+        assert matcher.match_all_streams(channel, candidates, aliases) == before
+    assert not parse_exclusions(["*", " * * ", None, ""])
+    assert parse_exclusions(r"\*") == [r"\*"]
+    # Direct checks cover patterns independently of positive-matcher eligibility.
+    # load_matcher does not register the module: helpers remain in method globals.
+    helpers = matcher._candidate_is_excluded.__func__.__globals__
+    compile_pattern = helpers["_exclusion_parts"]
+    match_pattern = helpers["_matches_exclusion"]
+    for pattern, name, expected in [
+        ("a*a", "a", False), ("a*a", "aa", True),
+        ("*ab*bc", "abc", False), ("*ab*bc", "abbc", True),
+        ("a**b***c", "abc", True), ("a*b*c", "acb", False),
+        ("*Game Show Central*", "game show centralization", True),
+        ("Game Show Central", "gameshowcentral", False),
+        ("*", "anything", False),
+    ]:
+        parts = compile_pattern(pattern)
+        actual = bool(parts and match_pattern(name, parts))
+        assert actual == expected, (pattern, name, actual)
+    # Quality bypass and callsign rescue must not revive excluded names.
+    for channel, candidates, aliases, kwargs in [
+        ("Example", ["US: Example 4K", "Example HD"],
+         {"Example": ["US: Example 4K", "Example HD"]}, {"quality_aware": True}),
+        ("My9 New York", ["US: MY 9 WWOR NEW YORK", "My9 New York"],
+         {"My9 New York": ["WWOR", "My9 New York"]}, {}),
+    ]:
+        before = matcher.match_all_streams(channel, candidates, aliases, **kwargs)
+        assert {m[0] for m in before} == set(candidates)
+        after = matcher.match_all_streams(channel, candidates, aliases,
+                                          excluded_aliases=[candidates[0]], **kwargs)
+        assert {m[0] for m in after} == {candidates[1]}
+
+
 def main() -> int:
     ap = argparse.ArgumentParser(description="Lineuparr matcher golden drift gate")
     ap.add_argument("--write", action="store_true", help="(re)generate the baseline from current code")
     args = ap.parse_args()
 
     matcher, parse_exclusions = load_matcher()
+    check_exclusion_regressions(matcher, parse_exclusions)
     current = run_corpus(matcher, parse_exclusions)
     if args.write:
         BASELINE.write_text(

--- a/.github/scripts/check_matcher_golden.py
+++ b/.github/scripts/check_matcher_golden.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Golden drift gate for Lineuparr's pure matcher primitives (Stage 0).
+"""Golden drift gate for Lineuparr's matcher primitives and exclusion contract.
 
 Lineuparr keeps its unit suite OUT of git (tests/ is gitignored) and CI runs only the
 static validate_plugin.py, so the matcher golden gate lives here in .github/scripts
@@ -66,21 +66,81 @@ def _safe(fn, *args, **kwargs):
         val = fn(*args, **kwargs)
     except Exception as exc:
         return f"__ERROR__: {type(exc).__name__}: {exc}"
-    if isinstance(val, float):
-        return round(val, 9)
-    return val
+    return _stable_value(val)
 
 
-def run_corpus(matcher):
+def _stable_value(value):
+    """Convert matcher output to the same JSON-native shape before comparison."""
+    if isinstance(value, float):
+        return round(value, 9)
+    if isinstance(value, (list, tuple)):
+        return [_stable_value(item) for item in value]
+    if isinstance(value, dict):
+        return {key: _stable_value(item) for key, item in value.items()}
+    return value
+
+
+def run_corpus(matcher, parse_excluded_aliases):
     out = {
         "process_string": {n: _safe(matcher.process_string_for_matching, n) for n in NAMES},
         "normalize_name": {},
         "calculate_similarity": {f"{a}|{b}": _safe(matcher.calculate_similarity, a, b) for a, b in PAIRS},
         "extract_callsign": {n: _safe(matcher.extract_callsign, n) for n in NAMES},
         "normalize_callsign": {n: _safe(matcher.normalize_callsign, n) for n in NAMES},
+        "excluded_aliases": {
+            "parse_string": _safe(parse_excluded_aliases, "  US-ReelzChannel  "),
+            "parse_list": _safe(
+                parse_excluded_aliases,
+                ["US-ReelzChannel", "us-reelzchannel", "Reelz Channel"],
+            ),
+            "parse_invalid_container": _safe(parse_excluded_aliases, {"bad": "value"}),
+            "parse_invalid_items": _safe(
+                parse_excluded_aliases, ["Reelz Channel", "", None, 42]
+            ),
+        },
     }
     for label, flags in FLAG_COMBOS:
         out["normalize_name"][label] = {n: _safe(matcher.normalize_name, n, **flags) for n in NAMES}
+    reelz_candidates = ["US-ReelzChannel", "US: Other Network HD"]
+    reelz_aliases = {
+        "REELZ": ["US-ReelzChannel"],
+        "Other Channel": ["US-ReelzChannel"],
+    }
+    quality_aliases = {"Example": ["US: Example 4K"]}
+    callsign_aliases = {"My9 New York": ["WWOR"]}
+    out["excluded_aliases"]["positive_alias"] = _safe(
+        matcher.match_all_streams, "REELZ", reelz_candidates, reelz_aliases
+    )
+    out["excluded_aliases"]["literal_blocks_positive_alias"] = _safe(
+        matcher.match_all_streams, "REELZ", reelz_candidates, reelz_aliases,
+        excluded_aliases="US-ReelzChannel",
+    )
+    out["excluded_aliases"]["normalized_variant_positive"] = _safe(
+        matcher.match_all_streams, "REELZ", ["US | Reelz Channel HD"], {}
+    )
+    out["excluded_aliases"]["normalized_variant"] = _safe(
+        matcher.match_all_streams, "REELZ", ["US | Reelz Channel HD"], {},
+        excluded_aliases=["ReelzChannel"],
+    )
+    out["excluded_aliases"]["channel_scoped"] = _safe(
+        matcher.match_all_streams, "Other Channel", ["US-ReelzChannel"], reelz_aliases
+    )
+    out["excluded_aliases"]["quality_bypass_positive"] = _safe(
+        matcher.match_all_streams, "Example", ["US: Example 4K"], quality_aliases,
+        quality_aware=True,
+    )
+    out["excluded_aliases"]["quality_bypass_blocked"] = _safe(
+        matcher.match_all_streams, "Example", ["US: Example 4K"], quality_aliases,
+        quality_aware=True, excluded_aliases=["Example 4K"],
+    )
+    out["excluded_aliases"]["callsign_rescue_blocked"] = _safe(
+        matcher.match_all_streams, "My9 New York", ["US: MY 9 WWOR NEW YORK"],
+        callsign_aliases, excluded_aliases=["US: MY 9 WWOR NEW YORK"],
+    )
+    out["excluded_aliases"]["regex_prefix_is_literal"] = _safe(
+        matcher.match_all_streams, "REELZ", ["US-ReelzChannel"], reelz_aliases,
+        excluded_aliases=["regex:^US-ReelzChannel$"],
+    )
     return out
 
 
@@ -107,7 +167,7 @@ def load_matcher():
         sys.modules.pop("aliases", None)
         if saved_aliases is not None:
             sys.modules["aliases"] = saved_aliases
-    return mod.FuzzyMatcher()
+    return mod.FuzzyMatcher(), mod.parse_excluded_aliases
 
 
 def main() -> int:
@@ -115,10 +175,12 @@ def main() -> int:
     ap.add_argument("--write", action="store_true", help="(re)generate the baseline from current code")
     args = ap.parse_args()
 
-    current = run_corpus(load_matcher())
+    matcher, parse_exclusions = load_matcher()
+    current = run_corpus(matcher, parse_exclusions)
     if args.write:
         BASELINE.write_text(
-            json.dumps(current, indent=2, ensure_ascii=False, sort_keys=True), encoding="utf-8"
+            json.dumps(current, indent=2, ensure_ascii=False, sort_keys=True) + "\n",
+            encoding="utf-8",
         )
         print(f"wrote {BASELINE}")
         return 0
@@ -132,12 +194,12 @@ def main() -> int:
              for k in sorted(set(base_flat) | set(cur_flat))
              if base_flat.get(k, "<missing>") != cur_flat.get(k, "<missing>")]
     if diffs:
-        print(f"MATCHER GOLDEN DRIFT ({len(diffs)} primitive output(s) changed):")
+        print(f"MATCHER GOLDEN DRIFT ({len(diffs)} matcher output(s) changed):")
         for key, old, new in diffs[:30]:
             print(f"  {key}:  {old!r}  ->  {new!r}")
         print("If intended, re-run with --write and commit the updated baseline.")
         return 1
-    print(f"Matcher golden gate passed ({len(base_flat)} primitive outputs match baseline).")
+    print(f"Matcher golden gate passed ({len(base_flat)} matcher outputs match baseline).")
     return 0
 
 

--- a/.github/scripts/matcher_golden_baseline.json
+++ b/.github/scripts/matcher_golden_baseline.json
@@ -15,6 +15,58 @@
     "usanetwork|usanetwork": 1.0,
     "|": 0.0
   },
+  "excluded_aliases": {
+    "callsign_rescue_blocked": [],
+    "channel_scoped": [
+      [
+        "US-ReelzChannel",
+        100,
+        "alias"
+      ]
+    ],
+    "literal_blocks_positive_alias": [],
+    "normalized_variant": [],
+    "normalized_variant_positive": [
+      [
+        "US | Reelz Channel HD",
+        100,
+        "exact"
+      ]
+    ],
+    "parse_invalid_container": [],
+    "parse_invalid_items": [
+      "Reelz Channel"
+    ],
+    "parse_list": [
+      "US-ReelzChannel",
+      "Reelz Channel"
+    ],
+    "parse_string": [
+      "US-ReelzChannel"
+    ],
+    "positive_alias": [
+      [
+        "US-ReelzChannel",
+        100,
+        "alias"
+      ]
+    ],
+    "quality_bypass_blocked": [],
+    "quality_bypass_positive": [
+      [
+        "US: Example 4K",
+        100,
+        "alias"
+      ]
+    ],
+    "regex_prefix_is_literal": [
+      [
+        "US-ReelzChannel",
+        100,
+        "alias"
+      ]
+    ]
+  },
   "extract_callsign": {
     "(D1) CBS": null,
     "(PRIME) FOX News": null,

--- a/.github/scripts/matcher_golden_baseline.json
+++ b/.github/scripts/matcher_golden_baseline.json
@@ -25,7 +25,6 @@
       ]
     ],
     "literal_blocks_positive_alias": [],
-    "normalized_variant": [],
     "normalized_variant_positive": [
       [
         "US | Reelz Channel HD",
@@ -51,7 +50,6 @@
         "alias"
       ]
     ],
-    "quality_bypass_blocked": [],
     "quality_bypass_positive": [
       [
         "US: Example 4K",
@@ -62,6 +60,20 @@
     "regex_prefix_is_literal": [
       [
         "US-ReelzChannel",
+        100,
+        "alias"
+      ]
+    ],
+    "unlisted_full_name_survives": [
+      [
+        "US | Reelz Channel HD",
+        100,
+        "exact"
+      ]
+    ],
+    "unlisted_quality_prefix_survives": [
+      [
+        "US: Example 4K",
         100,
         "alias"
       ]

--- a/.github/scripts/validate_plugin.py
+++ b/.github/scripts/validate_plugin.py
@@ -86,11 +86,11 @@ def check_lineups() -> None:
                             f"{path.name}: channel '{name}' in '{cat_name}' "
                             "excluded_aliases must be a string or list"
                         )
-                    elif any(not isinstance(value, str) or not value.strip()
+                    elif any(not isinstance(value, str) or not value.replace("*", "").strip()
                              for value in excluded_values):
                         err(
                             f"{path.name}: channel '{name}' in '{cat_name}' "
-                            "excluded_aliases must contain only non-empty strings"
+                            "excluded_aliases must contain non-empty strings, not wildcard-only patterns"
                         )
                 seen[name] = seen.get(name, 0) + 1
             dups = [f"{n!r} x{c}" for n, c in seen.items() if c > 1]

--- a/.github/scripts/validate_plugin.py
+++ b/.github/scripts/validate_plugin.py
@@ -78,6 +78,20 @@ def check_lineups() -> None:
                     err(f"{path.name}: {cat_name}[{i}] missing 'name'")
                 if "number" not in ch:
                     err(f"{path.name}: channel '{name}' in '{cat_name}' missing 'number'")
+                excluded = ch.get("excluded_aliases")
+                if excluded is not None:
+                    excluded_values = [excluded] if isinstance(excluded, str) else excluded
+                    if not isinstance(excluded_values, list):
+                        err(
+                            f"{path.name}: channel '{name}' in '{cat_name}' "
+                            "excluded_aliases must be a string or list"
+                        )
+                    elif any(not isinstance(value, str) or not value.strip()
+                             for value in excluded_values):
+                        err(
+                            f"{path.name}: channel '{name}' in '{cat_name}' "
+                            "excluded_aliases must contain only non-empty strings"
+                        )
                 seen[name] = seen.get(name, 0) + 1
             dups = [f"{n!r} x{c}" for n, c in seen.items() if c > 1]
             if dups:

--- a/Lineuparr/fuzzy_matcher.py
+++ b/Lineuparr/fuzzy_matcher.py
@@ -55,13 +55,52 @@ def has_upgrade_quality(name: str) -> bool:
     return bool(_UPGRADE_QUALITY_RE.search(name))
 
 
+def _exclusion_parts(value):
+    """Compile star-only patterns on raw names, never the lossy normalizer."""
+    value = " ".join(value.casefold().split())
+    parts = [""]
+    index = 0
+    while index < len(value):
+        char = value[index]
+        if char == "\\" and index + 1 < len(value) and value[index + 1] in "*\\":
+            index += 1
+            parts[-1] += value[index]
+        elif char == "*":
+            if parts[-1] or len(parts) == 1:
+                parts.append("")
+        else:
+            parts[-1] += char
+        index += 1
+    return tuple(parts) if any(part.strip() for part in parts) else None
+
+
+def _matches_exclusion(name, parts):
+    """Anchored star matching using ordered literal searches, not regex."""
+    if len(parts) == 1:
+        return name == parts[0]
+    if not name.startswith(parts[0]) or not name.endswith(parts[-1]):
+        return False
+    position = len(parts[0])
+    end = len(name) - len(parts[-1])
+    if position > end:
+        return False
+    for part in parts[1:-1]:
+        if not part:
+            continue
+        found = name.find(part, position, end)
+        if found < 0:
+            return False
+        position = found + len(part)
+    return position <= end
+
+
 def parse_excluded_aliases(raw, logger=None, channel_name=None):
     """Return a clean, de-duplicated list of channel-scoped exclusions.
 
     A lineup may use one string or a list of strings. Invalid values are
     ignored together and produce at most one warning for the channel, so one
     malformed list cannot flood a long matching run. Values are still plain
-    text here; match_all_streams applies the normal Lineuparr normalization.
+    text here; only case and whitespace are folded for exclusion comparison.
     """
     if raw is None:
         return []
@@ -85,6 +124,9 @@ def parse_excluded_aliases(raw, logger=None, channel_name=None):
             invalid += 1
             continue
         value = value.strip()
+        if _exclusion_parts(value) is None:
+            invalid += 1
+            continue
         key = value.casefold()
         if key in seen:
             continue
@@ -94,7 +136,7 @@ def parse_excluded_aliases(raw, logger=None, channel_name=None):
     if invalid and logger is not None:
         label = f" for channel '{channel_name}'" if channel_name else ""
         logger.warning(
-            f"[Lineuparr] Ignored {invalid} empty or non-string excluded_aliases "
+            f"[Lineuparr] Ignored {invalid} empty, wildcard-only, or non-string excluded_aliases "
             f"value{'s' if invalid != 1 else ''}{label}"
         )
     return cleaned
@@ -764,8 +806,9 @@ class FuzzyMatcher(FuzzyMatcherCore):
                 that prefix by platform ("GO:", "RK:", "PRIME:") rather than by country.
                 Omit it and matching behaves exactly as it did before.
             excluded_aliases: Optional string or list of stream names that must not
-                match this channel. Values use the same normalization as positive
-                aliases and are applied before every positive matching path.
+                match this channel. Raw full names are compared case-insensitively
+                with whitespace collapsed; unescaped * matches any text.
+                Applied before every positive matching path; not used for EPG.
 
         Returns:
             List of (stream_name, score, match_type) tuples sorted by score desc.
@@ -779,18 +822,11 @@ class FuzzyMatcher(FuzzyMatcherCore):
         # Channel-scoped exclusions are final. Filter before quality-aware alias
         # bypass, alias/callsign rescue, exact, substring, fuzzy, country/region
         # handling, and number boosts so no later stage can restore a denied pair.
-        excluded_keys = set()
-        for value in parse_excluded_aliases(excluded_aliases):
-            normalized = self.normalize_name(value, user_ignored_tags)
-            if not normalized:
-                continue
-            normalized = normalized.lower()
-            excluded_keys.add(normalized)
-            excluded_keys.add(re.sub(r'[\s&\-]+', '', normalized))
-        if excluded_keys:
+        exclusions = tuple(_exclusion_parts(value) for value in parse_excluded_aliases(excluded_aliases))
+        if exclusions:
             candidate_names = [
                 candidate for candidate in candidate_names
-                if not self._candidate_is_excluded(candidate, excluded_keys, user_ignored_tags)
+                if not self._candidate_is_excluded(candidate, exclusions)
             ]
             if not candidate_names:
                 return []
@@ -1103,11 +1139,7 @@ class FuzzyMatcher(FuzzyMatcherCore):
         )
         return results
 
-    def _candidate_is_excluded(self, candidate, excluded_keys, user_ignored_tags=None):
-        """Return True when candidate equals a normalized literal exclusion."""
-        candidate_lower, candidate_nospace = self._get_cached_norm(
-            candidate, user_ignored_tags
-        )
-        if not candidate_lower:
-            return False
-        return candidate_lower in excluded_keys or candidate_nospace in excluded_keys
+    def _candidate_is_excluded(self, candidate, exclusions):
+        """Preserve prefixes, words, punctuation and quality tags for exclusions."""
+        name = " ".join(candidate.casefold().split())
+        return any(_matches_exclusion(name, parts) for parts in exclusions)

--- a/Lineuparr/fuzzy_matcher.py
+++ b/Lineuparr/fuzzy_matcher.py
@@ -55,6 +55,51 @@ def has_upgrade_quality(name: str) -> bool:
     return bool(_UPGRADE_QUALITY_RE.search(name))
 
 
+def parse_excluded_aliases(raw, logger=None, channel_name=None):
+    """Return a clean, de-duplicated list of channel-scoped exclusions.
+
+    A lineup may use one string or a list of strings. Invalid values are
+    ignored together and produce at most one warning for the channel, so one
+    malformed list cannot flood a long matching run. Values are still plain
+    text here; match_all_streams applies the normal Lineuparr normalization.
+    """
+    if raw is None:
+        return []
+    if isinstance(raw, str):
+        values = [raw]
+    elif isinstance(raw, list):
+        values = raw
+    else:
+        if logger is not None:
+            label = f" for channel '{channel_name}'" if channel_name else ""
+            logger.warning(
+                f"[Lineuparr] Ignoring excluded_aliases{label}: expected a string or list"
+            )
+        return []
+
+    cleaned = []
+    seen = set()
+    invalid = 0
+    for value in values:
+        if not isinstance(value, str) or not value.strip():
+            invalid += 1
+            continue
+        value = value.strip()
+        key = value.casefold()
+        if key in seen:
+            continue
+        seen.add(key)
+        cleaned.append(value)
+
+    if invalid and logger is not None:
+        label = f" for channel '{channel_name}'" if channel_name else ""
+        logger.warning(
+            f"[Lineuparr] Ignored {invalid} empty or non-string excluded_aliases "
+            f"value{'s' if invalid != 1 else ''}{label}"
+        )
+    return cleaned
+
+
 # Country tokens for the delimited provider-prefix patterns below; curated so a
 # bare delimited word ("(SPORTS)") isn't misread as a country. Keep in sync with
 # detect_stream_country().
@@ -699,7 +744,7 @@ class FuzzyMatcher(FuzzyMatcherCore):
 
     def match_all_streams(self, lineup_name, candidate_names, alias_map, channel_number=None,
                           user_ignored_tags=None, lineup_country=None, quality_aware=False,
-                          candidate_countries=None):
+                          candidate_countries=None, excluded_aliases=None):
         """
         Full matching pipeline for Lineuparr: alias → exact → substring → fuzzy, with number boost.
         Returns ALL matching streams sorted by score.
@@ -718,6 +763,9 @@ class FuzzyMatcher(FuzzyMatcherCore):
                 name carries no country marker, which is the common case for providers
                 that prefix by platform ("GO:", "RK:", "PRIME:") rather than by country.
                 Omit it and matching behaves exactly as it did before.
+            excluded_aliases: Optional string or list of stream names that must not
+                match this channel. Values use the same normalization as positive
+                aliases and are applied before every positive matching path.
 
         Returns:
             List of (stream_name, score, match_type) tuples sorted by score desc.
@@ -727,6 +775,25 @@ class FuzzyMatcher(FuzzyMatcherCore):
 
         if user_ignored_tags is None:
             user_ignored_tags = []
+
+        # Channel-scoped exclusions are final. Filter before quality-aware alias
+        # bypass, alias/callsign rescue, exact, substring, fuzzy, country/region
+        # handling, and number boosts so no later stage can restore a denied pair.
+        excluded_keys = set()
+        for value in parse_excluded_aliases(excluded_aliases):
+            normalized = self.normalize_name(value, user_ignored_tags)
+            if not normalized:
+                continue
+            normalized = normalized.lower()
+            excluded_keys.add(normalized)
+            excluded_keys.add(re.sub(r'[\s&\-]+', '', normalized))
+        if excluded_keys:
+            candidate_names = [
+                candidate for candidate in candidate_names
+                if not self._candidate_is_excluded(candidate, excluded_keys, user_ignored_tags)
+            ]
+            if not candidate_names:
+                return []
 
         # Quality-aware pre-filtering (opt-in via quality_aware).
         # Both tiers are gated: upgrade channels only match upgrade streams,
@@ -1036,3 +1103,11 @@ class FuzzyMatcher(FuzzyMatcherCore):
         )
         return results
 
+    def _candidate_is_excluded(self, candidate, excluded_keys, user_ignored_tags=None):
+        """Return True when candidate equals a normalized literal exclusion."""
+        candidate_lower, candidate_nospace = self._get_cached_norm(
+            candidate, user_ignored_tags
+        )
+        if not candidate_lower:
+            return False
+        return candidate_lower in excluded_keys or candidate_nospace in excluded_keys

--- a/Lineuparr/plugin.py
+++ b/Lineuparr/plugin.py
@@ -19,7 +19,8 @@ from glob import glob
 from django.db import transaction
 
 from .fuzzy_matcher import (FuzzyMatcher, has_upgrade_quality, detect_category_country,
-                            detect_name_country_prefix, country_codes_in_text)
+                            detect_name_country_prefix, country_codes_in_text,
+                            parse_excluded_aliases)
 from .aliases import CHANNEL_ALIASES, COUNTRY_ALIASES
 from .progress_status import save_progress_atomic, load_progress, build_status_message
 from . import notify_bridge, report_count, reports
@@ -693,6 +694,7 @@ class Plugin:
         if "categories" not in data:
             raise ValueError(f"Invalid lineup file: missing 'categories' key")
 
+        self._normalize_excluded_aliases(data, logger)
         self._rewrite_country_prefixes(data, logger)
 
         # Apply category detail level transformation
@@ -702,6 +704,24 @@ class Plugin:
         self._lineup_cache_file = cache_key
         logger.info(f"{LOG_PREFIX} Loaded lineup: {data.get('package', 'Unknown')} ({sum(len(v) for v in data['categories'].values())} channels, {len(data['categories'])} categories, detail={detail})")
         return data
+
+    @staticmethod
+    def _normalize_excluded_aliases(data, logger):
+        """Normalize optional excluded_aliases fields once when a lineup loads."""
+        for channels in data.get("categories", {}).values():
+            if not isinstance(channels, list):
+                continue
+            for entry in channels:
+                if not isinstance(entry, dict) or "excluded_aliases" not in entry:
+                    continue
+                cleaned = parse_excluded_aliases(
+                    entry.get("excluded_aliases"), logger=logger,
+                    channel_name=entry.get("name"),
+                )
+                if cleaned:
+                    entry["excluded_aliases"] = cleaned
+                else:
+                    entry.pop("excluded_aliases", None)
 
     @staticmethod
     def _rewrite_country_prefixes(data, logger):
@@ -2211,6 +2231,7 @@ class Plugin:
                         lineup_country=entry_cc,
                         quality_aware=(ch_name in upgrade_twin_set),
                         candidate_countries=stream_countries,
+                        excluded_aliases=entry.get("excluded_aliases"),
                     )
 
                     if matches:
@@ -2917,6 +2938,7 @@ class Plugin:
                         lineup_country=entry_cc,
                         quality_aware=(ch_name in upgrade_twin_set),
                         candidate_countries=stream_countries,
+                        excluded_aliases=entry.get("excluded_aliases"),
                     )
 
                     if matches:

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ You pick a real provider lineup, such as Sky TV or DIRECTV Premier, and the plug
 
 - **Builds the lineup.** Channel groups and channels that mirror the provider's package, keeping the provider's channel numbers.
 - **Matches your streams to it.** A four stage pipeline: alias, exact, substring, then fuzzy token sort, with US broadcast callsign anchoring and length scaled thresholds to keep false positives down. Four sensitivity presets from Relaxed to Exact.
+- **Keeps reviewed false positives out.** Optional per-channel `excluded_aliases` block a known wrong stream before any positive matching stage without suppressing it from other channels.
 - **Rejects streams from the wrong country.** A lineup keeps only same country or untagged streams. Detection covers the tag formats real providers use, including parenthesized, colon separated, box bar separated, bare space, and country glued to a quality tag. When a stream name carries no country at all, the provider group it came from is read instead, which is what catches a provider that labels streams by platform rather than by country.
 - **Knows about regional variants**, so an East, West or Pacific channel reaches the matching regional stream.
 - **Assigns EPG data and logos.** Programme guides from any configured EPG source, and logos from EPG icons, the Logo Manager, or the [tv-logos](https://github.com/tv-logo/tv-logos) repository.

--- a/docs/LINEUP-FORMAT.md
+++ b/docs/LINEUP-FORMAT.md
@@ -86,22 +86,46 @@ looks like a good match but is known not to belong to that channel.
 
 ```json
 {
-  "name": "REELZ",
+  "name": "Game Show Network",
   "number": 128,
-  "aliases": ["Reelz Channel"],
-  "excluded_aliases": ["US-ReelzChannel"]
+  "aliases": ["GSN"],
+  "excluded_aliases": ["*Game Show Central*"]
 }
 ```
 
 A single exclusion may be a plain string instead of a one-item list. Exclusions
-use the same case, spacing, punctuation, provider-prefix and quality-tag
-normalization as aliases. They are channel-scoped: the excluded stream cannot
+compare original full stream names case-insensitively, trimming outer whitespace
+and collapsing repeated whitespace to one space. They do not use the lossy
+positive-alias normalizer: prefixes, punctuation, network words, quality tags,
+and word spacing remain significant. They are channel-scoped: the excluded stream cannot
 match this channel through an alias, callsign, exact, substring, fuzzy, quality
 bypass or channel-number boost, but it can still match another channel.
 
-Exclusions are literal names after normalization. Values such as `regex:`, `!`
-and glob characters have no special meaning. This keeps lineup files safe to
-load and makes a rejection as predictable as a positive alias.
+Without an unescaped `*`, the whole name must match. An unescaped `*` matches
+zero or more characters: `*Game Show Central*` rejects `US: Game Show Central HD`
+but preserves `Game Show Network` and does not match `GameShowCentral`.
+Patterns have no implicit word boundaries: that pattern also matches
+`Game Show Centralization`. Empty and wildcard-only patterns are invalid.
+Use Preview Stream Match to check broad exclusions before applying changes.
+
+Only `*` is a wildcard. Question marks, brackets, `!`, and regex syntax have
+no special meaning. Escape an asterisk with a backslash for a literal star;
+escape a backslash with another backslash. JSON requires those backslashes
+to be doubled. Other backslashes are literal. Matching uses ordered literal
+searches, not executable regular expressions.
+
+Exclusions affect stream matching only; they do not affect EPG/guide matching.
+The same stream name in multiple M3U accounts is excluded from this channel
+in every account. Preserve Existing Streams can retain previously attached
+excluded streams: an exclusion prevents new matching, not a guaranteed purge.
+Older plugin versions do not support this wildcard/escape contract.
+
+For example, this JSON excludes the literal title with asterisks, not
+arbitrary text between its letters:
+
+```json
+{"excluded_aliases": ["M\\*A\\*S\\*H"]}
+```
 
 ---
 

--- a/docs/LINEUP-FORMAT.md
+++ b/docs/LINEUP-FORMAT.md
@@ -79,6 +79,30 @@ Only an alias that is *entirely* a callsign counts. `WWOR` and `WWOR-TV` do;
 `WWOR New York` does not, because a display name is not a claim about which
 streams belong to the channel.
 
+## Per-channel excluded aliases
+
+A channel entry may also carry `excluded_aliases`. Use it for a stream name that
+looks like a good match but is known not to belong to that channel.
+
+```json
+{
+  "name": "REELZ",
+  "number": 128,
+  "aliases": ["Reelz Channel"],
+  "excluded_aliases": ["US-ReelzChannel"]
+}
+```
+
+A single exclusion may be a plain string instead of a one-item list. Exclusions
+use the same case, spacing, punctuation, provider-prefix and quality-tag
+normalization as aliases. They are channel-scoped: the excluded stream cannot
+match this channel through an alias, callsign, exact, substring, fuzzy, quality
+bypass or channel-number boost, but it can still match another channel.
+
+Exclusions are literal names after normalization. Values such as `regex:`, `!`
+and glob characters have no special meaning. This keeps lineup files safe to
+load and makes a rejection as predictable as a positive alias.
+
 ---
 
 ## Foreign channels inside a single-country lineup

--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -301,9 +301,11 @@ run's summary. The container logs carry the same detail.
 ## How matching works
 
 Before stream matching starts, a channel's optional `excluded_aliases` removes
-known wrong stream names using the same normalization as positive aliases. An
+known wrong stream names by case-insensitive full-name comparison with whitespace
+collapsed, before the lossy positive-name normalization is used. Unescaped
+`*` supports deliberate wildcard exclusions; escaped stars remain literal. An
 exclusion wins over every matching stage for that channel, while leaving the
-stream available to match a different channel. See the
+stream available to match a different channel. EPG matching is unaffected. See the
 [lineup file format](LINEUP-FORMAT.md#per-channel-excluded-aliases).
 
 Each lineup channel goes through four stages, in order, and stops at the first

--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -300,6 +300,12 @@ run's summary. The container logs carry the same detail.
 
 ## How matching works
 
+Before stream matching starts, a channel's optional `excluded_aliases` removes
+known wrong stream names using the same normalization as positive aliases. An
+exclusion wins over every matching stage for that channel, while leaving the
+stream available to match a different channel. See the
+[lineup file format](LINEUP-FORMAT.md#per-channel-excluded-aliases).
+
 Each lineup channel goes through four stages, in order, and stops at the first
 that produces a confident answer:
 


### PR DESCRIPTION
## Summary

Adds an optional per-channel `excluded_aliases` field to lineup JSON files. It prevents a known false-positive stream from attaching to that channel while leaving the stream eligible for other channels.

A rejected high-scoring match can currently return through a positive alias, exact or fuzzy matching, callsign rescue, quality-aware matching, or a channel-number boost. Removing a positive alias alone does not reliably prevent that. This field gives lineup authors a durable way to record the rejected channel/stream pairing.

```json
{
  "name": "Game Show Network",
  "number": 184,
  "aliases": ["GSN"],
  "excluded_aliases": ["Game Show Central"]
}
```

Game Show Central is a separate service that resembles Game Show Network closely enough to be selected incorrectly. The exclusion blocks only that false-positive pairing.

## Behavior

- Accepts either one string or a list of strings.
- Uses the same case, spacing, punctuation, provider-prefix, ignored-tag, and quality-tag normalization as positive matching.
- Applies before positive aliases, callsign rescue, exact, substring, fuzzy, quality-aware bypass, country/region acceptance, and channel-number boosts.
- Remains channel-scoped; excluding a stream from one channel does not suppress it globally.
- Treats exclusions as normalized literals. `regex:`, `!`, glob characters, and similar syntax have no executable meaning.
- Leaves existing lineup files unchanged when `excluded_aliases` is absent.
- Ignores malformed values from externally supplied lineups with a bounded warning. The committed-lineup validator rejects invalid field types and empty values.

## Implementation

- Normalizes `excluded_aliases` once when the lineup is loaded.
- Passes exclusions through both Preview Stream Match and Apply Stream Match.
- Filters excluded candidates before any positive matching path can select them.
- Extends the committed matcher golden corpus with exclusion parsing, normalization, precedence, quality-aware bypass, callsign rescue, channel scoping, and literal `regex:` coverage.
- Documents the field in the README, lineup format, and user guide.

## Validation

- `python3 .github/scripts/validate_plugin.py`
- Python byte compilation for both vendored modules
- Vendored matching-core parity
- Vendored notification-client parity
- Matcher golden gate: 307 outputs match the committed baseline
- Existing matcher outputs outside the new exclusion corpus remain unchanged
- `git diff --check`
- Live Dispatcharr validation confirmed that excluded streams were not attached to their affected channels, with no LineupARR exceptions or malformed-exclusion warnings during the full sync

## Scope and limitations

- No lineup data is changed.
- No plugin version bump is included.
- No regular-expression or glob matching is introduced.
- EPG matching is unchanged.
- Exclusions do not remove or disable streams globally.
